### PR TITLE
Revert "🚂 Added giphy support"

### DIFF
--- a/supported_hosts.js
+++ b/supported_hosts.js
@@ -10,11 +10,5 @@ window.SUPPORTED_HOSTS = [
     type: m => `video/${m[2]}`,
     domain: 'https://thumbs.gfycat.com https://zippy.gfycat.com https://fat.gfycat.com https://giant.gfycat.com',
     template: m => m[0]
-  },
-  {
-    pattern: /^https?://(media|i)\.giphy\.com\/media\/([^\/]+)\/giphy.*/,
-    type: m => `video/mp4`,
-    domain: 'https://media.giphy.com https://i.giphy.com http://media.giphy.com http://i.giphy.com',
-    template: m => `https://i.giphy.com/${m[2]}/giphy.mp4`
   }
 ]


### PR DESCRIPTION
Reverts qrohlf/GifHub#2

there's a syntax error in the Regex

![screen shot 2017-12-18 at 12 23 40 pm](https://user-images.githubusercontent.com/347189/34126435-6bd2c84c-e3ee-11e7-9b59-05af1d5bfabf.png)
