### PR TITLE
🛠 formats codebase, adds precommit hook for prettier

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  bracketSpacing: false,
+  semi: false,
+  printWidth: 120,
+  singleQuote: true
+}

--- a/background.js
+++ b/background.js
@@ -1,10 +1,13 @@
 /* global chrome, _, SUPPORTED_HOSTS */
-const CSP_WHITELIST = _(SUPPORTED_HOSTS).map(h => h.domain).uniq().join(' ')
+const CSP_WHITELIST = _(SUPPORTED_HOSTS)
+  .map(h => h.domain)
+  .uniq()
+  .join(' ')
 
-const onHeadersReceived = (details) => {
+const onHeadersReceived = details => {
   details.responseHeaders.forEach(header => {
     if (header.name.match(/content-security-policy/i)) {
-      header.value = (header.value.replace(/media-src.*?;/, 'media-src ' + CSP_WHITELIST + ';'))
+      header.value = header.value.replace(/"media-src.*?;/, 'media-src ' + CSP_WHITELIST + ';')
     }
   })
 

--- a/gifhub.js
+++ b/gifhub.js
@@ -6,7 +6,7 @@ const createWithAttrs = (tag, attrs = {}) => {
   return node
 }
 
-const getVideoNode = (href) => {
+const getVideoNode = href => {
   const host = SUPPORTED_HOSTS.find(h => href.match(h.pattern))
   if (!host) return null
   const matches = href.match(host.pattern)
@@ -25,7 +25,7 @@ const getVideoNode = (href) => {
   return video
 }
 
-const getPlayer = (videoNode) => {
+const getPlayer = videoNode => {
   const blockContainer = createWithAttrs('div')
 
   const videoContainer = createWithAttrs('div', {
@@ -74,9 +74,9 @@ const getPlayer = (videoNode) => {
     playButton.style.opacity = 0.6
   })
 
-  const showPlayOverlay = () => { playOverlay.style.opacity = 1 }
-  const hidePlayOverlay = () => { playOverlay.style.opacity = 0 }
-  const updateUI = () => { videoNode.paused ? showPlayOverlay() : hidePlayOverlay() }
+  const showPlayOverlay = () => (playOverlay.style.opacity = 1)
+  const hidePlayOverlay = () => (playOverlay.style.opacity = 0)
+  const updateUI = () => (videoNode.paused ? showPlayOverlay() : hidePlayOverlay())
 
   playOverlay.appendChild(playButton)
   videoContainer.appendChild(videoNode)
@@ -85,7 +85,8 @@ const getPlayer = (videoNode) => {
 
   playOverlay.addEventListener('click', () => {
     if (videoNode.paused) {
-      videoNode.play()
+      videoNode
+        .play()
         .then(updateUI)
         .catch(updateUI)
     } else {
@@ -94,7 +95,8 @@ const getPlayer = (videoNode) => {
     }
   })
 
-  videoNode.play()
+  videoNode
+    .play()
     .then(updateUI)
     .catch(updateUI)
 
@@ -103,7 +105,8 @@ const getPlayer = (videoNode) => {
 
 const processPage = () => {
   // grab all valid links that don't already have a video
-  const commentLinks = Array.prototype.slice.call(document.querySelectorAll('.comment-body a'))
+  const commentLinks = Array.prototype.slice
+    .call(document.querySelectorAll('.comment-body a'))
     .filter(a => !a.querySelector('video'))
     .filter(a => a.href && a.href !== '' && SUPPORTED_HOSTS.some(host => a.href.match(host.pattern)))
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,14 @@
   "license": "WTFPL",
   "private": true,
   "devDependencies": {
+    "husky": "^1.0.0-rc.13",
+    "precise-commits": "^1.0.2",
+    "prettier": "^1.14.2",
     "standard": "^10.0.2"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "precise-commits"
+    }
   }
 }

--- a/vendor/lodash.js
+++ b/vendor/lodash.js
@@ -7,73 +7,72 @@
  * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
  */
 ;(function() {
-
   /** Used as a safe reference for `undefined` in pre-ES5 environments. */
-  var undefined;
+  var undefined
 
   /** Used as the semantic version number. */
-  var VERSION = '4.17.4';
+  var VERSION = '4.17.4'
 
   /** Used as the size to enable large array optimizations. */
-  var LARGE_ARRAY_SIZE = 200;
+  var LARGE_ARRAY_SIZE = 200
 
   /** Error message constants. */
   var CORE_ERROR_TEXT = 'Unsupported core-js use. Try https://npms.io/search?q=ponyfill.',
-      FUNC_ERROR_TEXT = 'Expected a function';
+    FUNC_ERROR_TEXT = 'Expected a function'
 
   /** Used to stand-in for `undefined` hash values. */
-  var HASH_UNDEFINED = '__lodash_hash_undefined__';
+  var HASH_UNDEFINED = '__lodash_hash_undefined__'
 
   /** Used as the maximum memoize cache size. */
-  var MAX_MEMOIZE_SIZE = 500;
+  var MAX_MEMOIZE_SIZE = 500
 
   /** Used as the internal argument placeholder. */
-  var PLACEHOLDER = '__lodash_placeholder__';
+  var PLACEHOLDER = '__lodash_placeholder__'
 
   /** Used to compose bitmasks for cloning. */
   var CLONE_DEEP_FLAG = 1,
-      CLONE_FLAT_FLAG = 2,
-      CLONE_SYMBOLS_FLAG = 4;
+    CLONE_FLAT_FLAG = 2,
+    CLONE_SYMBOLS_FLAG = 4
 
   /** Used to compose bitmasks for value comparisons. */
   var COMPARE_PARTIAL_FLAG = 1,
-      COMPARE_UNORDERED_FLAG = 2;
+    COMPARE_UNORDERED_FLAG = 2
 
   /** Used to compose bitmasks for function metadata. */
   var WRAP_BIND_FLAG = 1,
-      WRAP_BIND_KEY_FLAG = 2,
-      WRAP_CURRY_BOUND_FLAG = 4,
-      WRAP_CURRY_FLAG = 8,
-      WRAP_CURRY_RIGHT_FLAG = 16,
-      WRAP_PARTIAL_FLAG = 32,
-      WRAP_PARTIAL_RIGHT_FLAG = 64,
-      WRAP_ARY_FLAG = 128,
-      WRAP_REARG_FLAG = 256,
-      WRAP_FLIP_FLAG = 512;
+    WRAP_BIND_KEY_FLAG = 2,
+    WRAP_CURRY_BOUND_FLAG = 4,
+    WRAP_CURRY_FLAG = 8,
+    WRAP_CURRY_RIGHT_FLAG = 16,
+    WRAP_PARTIAL_FLAG = 32,
+    WRAP_PARTIAL_RIGHT_FLAG = 64,
+    WRAP_ARY_FLAG = 128,
+    WRAP_REARG_FLAG = 256,
+    WRAP_FLIP_FLAG = 512
 
   /** Used as default options for `_.truncate`. */
   var DEFAULT_TRUNC_LENGTH = 30,
-      DEFAULT_TRUNC_OMISSION = '...';
+    DEFAULT_TRUNC_OMISSION = '...'
 
   /** Used to detect hot functions by number of calls within a span of milliseconds. */
   var HOT_COUNT = 800,
-      HOT_SPAN = 16;
+    HOT_SPAN = 16
 
   /** Used to indicate the type of lazy iteratees. */
   var LAZY_FILTER_FLAG = 1,
-      LAZY_MAP_FLAG = 2,
-      LAZY_WHILE_FLAG = 3;
+    LAZY_MAP_FLAG = 2,
+    LAZY_WHILE_FLAG = 3
 
   /** Used as references for various `Number` constants. */
   var INFINITY = 1 / 0,
-      MAX_SAFE_INTEGER = 9007199254740991,
-      MAX_INTEGER = 1.7976931348623157e+308,
-      NAN = 0 / 0;
+    MAX_SAFE_INTEGER = 9007199254740991,
+    MAX_INTEGER = 1.7976931348623157e308,
+    NAN = 0 / 0
 
   /** Used as references for the maximum length and index of an array. */
   var MAX_ARRAY_LENGTH = 4294967295,
-      MAX_ARRAY_INDEX = MAX_ARRAY_LENGTH - 1,
-      HALF_MAX_ARRAY_LENGTH = MAX_ARRAY_LENGTH >>> 1;
+    MAX_ARRAY_INDEX = MAX_ARRAY_LENGTH - 1,
+    HALF_MAX_ARRAY_LENGTH = MAX_ARRAY_LENGTH >>> 1
 
   /** Used to associate wrap methods with their bit flags. */
   var wrapFlags = [
@@ -86,300 +85,466 @@
     ['partial', WRAP_PARTIAL_FLAG],
     ['partialRight', WRAP_PARTIAL_RIGHT_FLAG],
     ['rearg', WRAP_REARG_FLAG]
-  ];
+  ]
 
   /** `Object#toString` result references. */
   var argsTag = '[object Arguments]',
-      arrayTag = '[object Array]',
-      asyncTag = '[object AsyncFunction]',
-      boolTag = '[object Boolean]',
-      dateTag = '[object Date]',
-      domExcTag = '[object DOMException]',
-      errorTag = '[object Error]',
-      funcTag = '[object Function]',
-      genTag = '[object GeneratorFunction]',
-      mapTag = '[object Map]',
-      numberTag = '[object Number]',
-      nullTag = '[object Null]',
-      objectTag = '[object Object]',
-      promiseTag = '[object Promise]',
-      proxyTag = '[object Proxy]',
-      regexpTag = '[object RegExp]',
-      setTag = '[object Set]',
-      stringTag = '[object String]',
-      symbolTag = '[object Symbol]',
-      undefinedTag = '[object Undefined]',
-      weakMapTag = '[object WeakMap]',
-      weakSetTag = '[object WeakSet]';
+    arrayTag = '[object Array]',
+    asyncTag = '[object AsyncFunction]',
+    boolTag = '[object Boolean]',
+    dateTag = '[object Date]',
+    domExcTag = '[object DOMException]',
+    errorTag = '[object Error]',
+    funcTag = '[object Function]',
+    genTag = '[object GeneratorFunction]',
+    mapTag = '[object Map]',
+    numberTag = '[object Number]',
+    nullTag = '[object Null]',
+    objectTag = '[object Object]',
+    promiseTag = '[object Promise]',
+    proxyTag = '[object Proxy]',
+    regexpTag = '[object RegExp]',
+    setTag = '[object Set]',
+    stringTag = '[object String]',
+    symbolTag = '[object Symbol]',
+    undefinedTag = '[object Undefined]',
+    weakMapTag = '[object WeakMap]',
+    weakSetTag = '[object WeakSet]'
 
   var arrayBufferTag = '[object ArrayBuffer]',
-      dataViewTag = '[object DataView]',
-      float32Tag = '[object Float32Array]',
-      float64Tag = '[object Float64Array]',
-      int8Tag = '[object Int8Array]',
-      int16Tag = '[object Int16Array]',
-      int32Tag = '[object Int32Array]',
-      uint8Tag = '[object Uint8Array]',
-      uint8ClampedTag = '[object Uint8ClampedArray]',
-      uint16Tag = '[object Uint16Array]',
-      uint32Tag = '[object Uint32Array]';
+    dataViewTag = '[object DataView]',
+    float32Tag = '[object Float32Array]',
+    float64Tag = '[object Float64Array]',
+    int8Tag = '[object Int8Array]',
+    int16Tag = '[object Int16Array]',
+    int32Tag = '[object Int32Array]',
+    uint8Tag = '[object Uint8Array]',
+    uint8ClampedTag = '[object Uint8ClampedArray]',
+    uint16Tag = '[object Uint16Array]',
+    uint32Tag = '[object Uint32Array]'
 
   /** Used to match empty string literals in compiled template source. */
   var reEmptyStringLeading = /\b__p \+= '';/g,
-      reEmptyStringMiddle = /\b(__p \+=) '' \+/g,
-      reEmptyStringTrailing = /(__e\(.*?\)|\b__t\)) \+\n'';/g;
+    reEmptyStringMiddle = /\b(__p \+=) '' \+/g,
+    reEmptyStringTrailing = /(__e\(.*?\)|\b__t\)) \+\n'';/g
 
   /** Used to match HTML entities and HTML characters. */
   var reEscapedHtml = /&(?:amp|lt|gt|quot|#39);/g,
-      reUnescapedHtml = /[&<>"']/g,
-      reHasEscapedHtml = RegExp(reEscapedHtml.source),
-      reHasUnescapedHtml = RegExp(reUnescapedHtml.source);
+    reUnescapedHtml = /[&<>"']/g,
+    reHasEscapedHtml = RegExp(reEscapedHtml.source),
+    reHasUnescapedHtml = RegExp(reUnescapedHtml.source)
 
   /** Used to match template delimiters. */
   var reEscape = /<%-([\s\S]+?)%>/g,
-      reEvaluate = /<%([\s\S]+?)%>/g,
-      reInterpolate = /<%=([\s\S]+?)%>/g;
+    reEvaluate = /<%([\s\S]+?)%>/g,
+    reInterpolate = /<%=([\s\S]+?)%>/g
 
   /** Used to match property names within property paths. */
   var reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/,
-      reIsPlainProp = /^\w*$/,
-      reLeadingDot = /^\./,
-      rePropName = /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))/g;
+    reIsPlainProp = /^\w*$/,
+    reLeadingDot = /^\./,
+    rePropName = /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))/g
 
   /**
    * Used to match `RegExp`
    * [syntax characters](http://ecma-international.org/ecma-262/7.0/#sec-patterns).
    */
   var reRegExpChar = /[\\^$.*+?()[\]{}|]/g,
-      reHasRegExpChar = RegExp(reRegExpChar.source);
+    reHasRegExpChar = RegExp(reRegExpChar.source)
 
   /** Used to match leading and trailing whitespace. */
   var reTrim = /^\s+|\s+$/g,
-      reTrimStart = /^\s+/,
-      reTrimEnd = /\s+$/;
+    reTrimStart = /^\s+/,
+    reTrimEnd = /\s+$/
 
   /** Used to match wrap detail comments. */
   var reWrapComment = /\{(?:\n\/\* \[wrapped with .+\] \*\/)?\n?/,
-      reWrapDetails = /\{\n\/\* \[wrapped with (.+)\] \*/,
-      reSplitDetails = /,? & /;
+    reWrapDetails = /\{\n\/\* \[wrapped with (.+)\] \*/,
+    reSplitDetails = /,? & /
 
   /** Used to match words composed of alphanumeric characters. */
-  var reAsciiWord = /[^\x00-\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]+/g;
+  var reAsciiWord = /[^\x00-\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]+/g
 
   /** Used to match backslashes in property paths. */
-  var reEscapeChar = /\\(\\)?/g;
+  var reEscapeChar = /\\(\\)?/g
 
   /**
    * Used to match
    * [ES template delimiters](http://ecma-international.org/ecma-262/7.0/#sec-template-literal-lexical-components).
    */
-  var reEsTemplate = /\$\{([^\\}]*(?:\\.[^\\}]*)*)\}/g;
+  var reEsTemplate = /\$\{([^\\}]*(?:\\.[^\\}]*)*)\}/g
 
   /** Used to match `RegExp` flags from their coerced string values. */
-  var reFlags = /\w*$/;
+  var reFlags = /\w*$/
 
   /** Used to detect bad signed hexadecimal string values. */
-  var reIsBadHex = /^[-+]0x[0-9a-f]+$/i;
+  var reIsBadHex = /^[-+]0x[0-9a-f]+$/i
 
   /** Used to detect binary string values. */
-  var reIsBinary = /^0b[01]+$/i;
+  var reIsBinary = /^0b[01]+$/i
 
   /** Used to detect host constructors (Safari). */
-  var reIsHostCtor = /^\[object .+?Constructor\]$/;
+  var reIsHostCtor = /^\[object .+?Constructor\]$/
 
   /** Used to detect octal string values. */
-  var reIsOctal = /^0o[0-7]+$/i;
+  var reIsOctal = /^0o[0-7]+$/i
 
   /** Used to detect unsigned integer values. */
-  var reIsUint = /^(?:0|[1-9]\d*)$/;
+  var reIsUint = /^(?:0|[1-9]\d*)$/
 
   /** Used to match Latin Unicode letters (excluding mathematical operators). */
-  var reLatin = /[\xc0-\xd6\xd8-\xf6\xf8-\xff\u0100-\u017f]/g;
+  var reLatin = /[\xc0-\xd6\xd8-\xf6\xf8-\xff\u0100-\u017f]/g
 
   /** Used to ensure capturing order of template delimiters. */
-  var reNoMatch = /($^)/;
+  var reNoMatch = /($^)/
 
   /** Used to match unescaped characters in compiled string literals. */
-  var reUnescapedString = /['\n\r\u2028\u2029\\]/g;
+  var reUnescapedString = /['\n\r\u2028\u2029\\]/g
 
   /** Used to compose unicode character classes. */
   var rsAstralRange = '\\ud800-\\udfff',
-      rsComboMarksRange = '\\u0300-\\u036f',
-      reComboHalfMarksRange = '\\ufe20-\\ufe2f',
-      rsComboSymbolsRange = '\\u20d0-\\u20ff',
-      rsComboRange = rsComboMarksRange + reComboHalfMarksRange + rsComboSymbolsRange,
-      rsDingbatRange = '\\u2700-\\u27bf',
-      rsLowerRange = 'a-z\\xdf-\\xf6\\xf8-\\xff',
-      rsMathOpRange = '\\xac\\xb1\\xd7\\xf7',
-      rsNonCharRange = '\\x00-\\x2f\\x3a-\\x40\\x5b-\\x60\\x7b-\\xbf',
-      rsPunctuationRange = '\\u2000-\\u206f',
-      rsSpaceRange = ' \\t\\x0b\\f\\xa0\\ufeff\\n\\r\\u2028\\u2029\\u1680\\u180e\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007\\u2008\\u2009\\u200a\\u202f\\u205f\\u3000',
-      rsUpperRange = 'A-Z\\xc0-\\xd6\\xd8-\\xde',
-      rsVarRange = '\\ufe0e\\ufe0f',
-      rsBreakRange = rsMathOpRange + rsNonCharRange + rsPunctuationRange + rsSpaceRange;
+    rsComboMarksRange = '\\u0300-\\u036f',
+    reComboHalfMarksRange = '\\ufe20-\\ufe2f',
+    rsComboSymbolsRange = '\\u20d0-\\u20ff',
+    rsComboRange = rsComboMarksRange + reComboHalfMarksRange + rsComboSymbolsRange,
+    rsDingbatRange = '\\u2700-\\u27bf',
+    rsLowerRange = 'a-z\\xdf-\\xf6\\xf8-\\xff',
+    rsMathOpRange = '\\xac\\xb1\\xd7\\xf7',
+    rsNonCharRange = '\\x00-\\x2f\\x3a-\\x40\\x5b-\\x60\\x7b-\\xbf',
+    rsPunctuationRange = '\\u2000-\\u206f',
+    rsSpaceRange =
+      ' \\t\\x0b\\f\\xa0\\ufeff\\n\\r\\u2028\\u2029\\u1680\\u180e\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007\\u2008\\u2009\\u200a\\u202f\\u205f\\u3000',
+    rsUpperRange = 'A-Z\\xc0-\\xd6\\xd8-\\xde',
+    rsVarRange = '\\ufe0e\\ufe0f',
+    rsBreakRange = rsMathOpRange + rsNonCharRange + rsPunctuationRange + rsSpaceRange
 
   /** Used to compose unicode capture groups. */
   var rsApos = "['\u2019]",
-      rsAstral = '[' + rsAstralRange + ']',
-      rsBreak = '[' + rsBreakRange + ']',
-      rsCombo = '[' + rsComboRange + ']',
-      rsDigits = '\\d+',
-      rsDingbat = '[' + rsDingbatRange + ']',
-      rsLower = '[' + rsLowerRange + ']',
-      rsMisc = '[^' + rsAstralRange + rsBreakRange + rsDigits + rsDingbatRange + rsLowerRange + rsUpperRange + ']',
-      rsFitz = '\\ud83c[\\udffb-\\udfff]',
-      rsModifier = '(?:' + rsCombo + '|' + rsFitz + ')',
-      rsNonAstral = '[^' + rsAstralRange + ']',
-      rsRegional = '(?:\\ud83c[\\udde6-\\uddff]){2}',
-      rsSurrPair = '[\\ud800-\\udbff][\\udc00-\\udfff]',
-      rsUpper = '[' + rsUpperRange + ']',
-      rsZWJ = '\\u200d';
+    rsAstral = '[' + rsAstralRange + ']',
+    rsBreak = '[' + rsBreakRange + ']',
+    rsCombo = '[' + rsComboRange + ']',
+    rsDigits = '\\d+',
+    rsDingbat = '[' + rsDingbatRange + ']',
+    rsLower = '[' + rsLowerRange + ']',
+    rsMisc = '[^' + rsAstralRange + rsBreakRange + rsDigits + rsDingbatRange + rsLowerRange + rsUpperRange + ']',
+    rsFitz = '\\ud83c[\\udffb-\\udfff]',
+    rsModifier = '(?:' + rsCombo + '|' + rsFitz + ')',
+    rsNonAstral = '[^' + rsAstralRange + ']',
+    rsRegional = '(?:\\ud83c[\\udde6-\\uddff]){2}',
+    rsSurrPair = '[\\ud800-\\udbff][\\udc00-\\udfff]',
+    rsUpper = '[' + rsUpperRange + ']',
+    rsZWJ = '\\u200d'
 
   /** Used to compose unicode regexes. */
   var rsMiscLower = '(?:' + rsLower + '|' + rsMisc + ')',
-      rsMiscUpper = '(?:' + rsUpper + '|' + rsMisc + ')',
-      rsOptContrLower = '(?:' + rsApos + '(?:d|ll|m|re|s|t|ve))?',
-      rsOptContrUpper = '(?:' + rsApos + '(?:D|LL|M|RE|S|T|VE))?',
-      reOptMod = rsModifier + '?',
-      rsOptVar = '[' + rsVarRange + ']?',
-      rsOptJoin = '(?:' + rsZWJ + '(?:' + [rsNonAstral, rsRegional, rsSurrPair].join('|') + ')' + rsOptVar + reOptMod + ')*',
-      rsOrdLower = '\\d*(?:(?:1st|2nd|3rd|(?![123])\\dth)\\b)',
-      rsOrdUpper = '\\d*(?:(?:1ST|2ND|3RD|(?![123])\\dTH)\\b)',
-      rsSeq = rsOptVar + reOptMod + rsOptJoin,
-      rsEmoji = '(?:' + [rsDingbat, rsRegional, rsSurrPair].join('|') + ')' + rsSeq,
-      rsSymbol = '(?:' + [rsNonAstral + rsCombo + '?', rsCombo, rsRegional, rsSurrPair, rsAstral].join('|') + ')';
+    rsMiscUpper = '(?:' + rsUpper + '|' + rsMisc + ')',
+    rsOptContrLower = '(?:' + rsApos + '(?:d|ll|m|re|s|t|ve))?',
+    rsOptContrUpper = '(?:' + rsApos + '(?:D|LL|M|RE|S|T|VE))?',
+    reOptMod = rsModifier + '?',
+    rsOptVar = '[' + rsVarRange + ']?',
+    rsOptJoin =
+      '(?:' + rsZWJ + '(?:' + [rsNonAstral, rsRegional, rsSurrPair].join('|') + ')' + rsOptVar + reOptMod + ')*',
+    rsOrdLower = '\\d*(?:(?:1st|2nd|3rd|(?![123])\\dth)\\b)',
+    rsOrdUpper = '\\d*(?:(?:1ST|2ND|3RD|(?![123])\\dTH)\\b)',
+    rsSeq = rsOptVar + reOptMod + rsOptJoin,
+    rsEmoji = '(?:' + [rsDingbat, rsRegional, rsSurrPair].join('|') + ')' + rsSeq,
+    rsSymbol = '(?:' + [rsNonAstral + rsCombo + '?', rsCombo, rsRegional, rsSurrPair, rsAstral].join('|') + ')'
 
   /** Used to match apostrophes. */
-  var reApos = RegExp(rsApos, 'g');
+  var reApos = RegExp(rsApos, 'g')
 
   /**
    * Used to match [combining diacritical marks](https://en.wikipedia.org/wiki/Combining_Diacritical_Marks) and
    * [combining diacritical marks for symbols](https://en.wikipedia.org/wiki/Combining_Diacritical_Marks_for_Symbols).
    */
-  var reComboMark = RegExp(rsCombo, 'g');
+  var reComboMark = RegExp(rsCombo, 'g')
 
   /** Used to match [string symbols](https://mathiasbynens.be/notes/javascript-unicode). */
-  var reUnicode = RegExp(rsFitz + '(?=' + rsFitz + ')|' + rsSymbol + rsSeq, 'g');
+  var reUnicode = RegExp(rsFitz + '(?=' + rsFitz + ')|' + rsSymbol + rsSeq, 'g')
 
   /** Used to match complex or compound words. */
-  var reUnicodeWord = RegExp([
-    rsUpper + '?' + rsLower + '+' + rsOptContrLower + '(?=' + [rsBreak, rsUpper, '$'].join('|') + ')',
-    rsMiscUpper + '+' + rsOptContrUpper + '(?=' + [rsBreak, rsUpper + rsMiscLower, '$'].join('|') + ')',
-    rsUpper + '?' + rsMiscLower + '+' + rsOptContrLower,
-    rsUpper + '+' + rsOptContrUpper,
-    rsOrdUpper,
-    rsOrdLower,
-    rsDigits,
-    rsEmoji
-  ].join('|'), 'g');
+  var reUnicodeWord = RegExp(
+    [
+      rsUpper + '?' + rsLower + '+' + rsOptContrLower + '(?=' + [rsBreak, rsUpper, '$'].join('|') + ')',
+      rsMiscUpper + '+' + rsOptContrUpper + '(?=' + [rsBreak, rsUpper + rsMiscLower, '$'].join('|') + ')',
+      rsUpper + '?' + rsMiscLower + '+' + rsOptContrLower,
+      rsUpper + '+' + rsOptContrUpper,
+      rsOrdUpper,
+      rsOrdLower,
+      rsDigits,
+      rsEmoji
+    ].join('|'),
+    'g'
+  )
 
   /** Used to detect strings with [zero-width joiners or code points from the astral planes](http://eev.ee/blog/2015/09/12/dark-corners-of-unicode/). */
-  var reHasUnicode = RegExp('[' + rsZWJ + rsAstralRange  + rsComboRange + rsVarRange + ']');
+  var reHasUnicode = RegExp('[' + rsZWJ + rsAstralRange + rsComboRange + rsVarRange + ']')
 
   /** Used to detect strings that need a more robust regexp to match words. */
-  var reHasUnicodeWord = /[a-z][A-Z]|[A-Z]{2,}[a-z]|[0-9][a-zA-Z]|[a-zA-Z][0-9]|[^a-zA-Z0-9 ]/;
+  var reHasUnicodeWord = /[a-z][A-Z]|[A-Z]{2,}[a-z]|[0-9][a-zA-Z]|[a-zA-Z][0-9]|[^a-zA-Z0-9 ]/
 
   /** Used to assign default `context` object properties. */
   var contextProps = [
-    'Array', 'Buffer', 'DataView', 'Date', 'Error', 'Float32Array', 'Float64Array',
-    'Function', 'Int8Array', 'Int16Array', 'Int32Array', 'Map', 'Math', 'Object',
-    'Promise', 'RegExp', 'Set', 'String', 'Symbol', 'TypeError', 'Uint8Array',
-    'Uint8ClampedArray', 'Uint16Array', 'Uint32Array', 'WeakMap',
-    '_', 'clearTimeout', 'isFinite', 'parseInt', 'setTimeout'
-  ];
+    'Array',
+    'Buffer',
+    'DataView',
+    'Date',
+    'Error',
+    'Float32Array',
+    'Float64Array',
+    'Function',
+    'Int8Array',
+    'Int16Array',
+    'Int32Array',
+    'Map',
+    'Math',
+    'Object',
+    'Promise',
+    'RegExp',
+    'Set',
+    'String',
+    'Symbol',
+    'TypeError',
+    'Uint8Array',
+    'Uint8ClampedArray',
+    'Uint16Array',
+    'Uint32Array',
+    'WeakMap',
+    '_',
+    'clearTimeout',
+    'isFinite',
+    'parseInt',
+    'setTimeout'
+  ]
 
   /** Used to make template sourceURLs easier to identify. */
-  var templateCounter = -1;
+  var templateCounter = -1
 
   /** Used to identify `toStringTag` values of typed arrays. */
-  var typedArrayTags = {};
-  typedArrayTags[float32Tag] = typedArrayTags[float64Tag] =
-  typedArrayTags[int8Tag] = typedArrayTags[int16Tag] =
-  typedArrayTags[int32Tag] = typedArrayTags[uint8Tag] =
-  typedArrayTags[uint8ClampedTag] = typedArrayTags[uint16Tag] =
-  typedArrayTags[uint32Tag] = true;
-  typedArrayTags[argsTag] = typedArrayTags[arrayTag] =
-  typedArrayTags[arrayBufferTag] = typedArrayTags[boolTag] =
-  typedArrayTags[dataViewTag] = typedArrayTags[dateTag] =
-  typedArrayTags[errorTag] = typedArrayTags[funcTag] =
-  typedArrayTags[mapTag] = typedArrayTags[numberTag] =
-  typedArrayTags[objectTag] = typedArrayTags[regexpTag] =
-  typedArrayTags[setTag] = typedArrayTags[stringTag] =
-  typedArrayTags[weakMapTag] = false;
+  var typedArrayTags = {}
+  typedArrayTags[float32Tag] = typedArrayTags[float64Tag] = typedArrayTags[int8Tag] = typedArrayTags[
+    int16Tag
+  ] = typedArrayTags[int32Tag] = typedArrayTags[uint8Tag] = typedArrayTags[uint8ClampedTag] = typedArrayTags[
+    uint16Tag
+  ] = typedArrayTags[uint32Tag] = true
+  typedArrayTags[argsTag] = typedArrayTags[arrayTag] = typedArrayTags[arrayBufferTag] = typedArrayTags[
+    boolTag
+  ] = typedArrayTags[dataViewTag] = typedArrayTags[dateTag] = typedArrayTags[errorTag] = typedArrayTags[
+    funcTag
+  ] = typedArrayTags[mapTag] = typedArrayTags[numberTag] = typedArrayTags[objectTag] = typedArrayTags[
+    regexpTag
+  ] = typedArrayTags[setTag] = typedArrayTags[stringTag] = typedArrayTags[weakMapTag] = false
 
   /** Used to identify `toStringTag` values supported by `_.clone`. */
-  var cloneableTags = {};
-  cloneableTags[argsTag] = cloneableTags[arrayTag] =
-  cloneableTags[arrayBufferTag] = cloneableTags[dataViewTag] =
-  cloneableTags[boolTag] = cloneableTags[dateTag] =
-  cloneableTags[float32Tag] = cloneableTags[float64Tag] =
-  cloneableTags[int8Tag] = cloneableTags[int16Tag] =
-  cloneableTags[int32Tag] = cloneableTags[mapTag] =
-  cloneableTags[numberTag] = cloneableTags[objectTag] =
-  cloneableTags[regexpTag] = cloneableTags[setTag] =
-  cloneableTags[stringTag] = cloneableTags[symbolTag] =
-  cloneableTags[uint8Tag] = cloneableTags[uint8ClampedTag] =
-  cloneableTags[uint16Tag] = cloneableTags[uint32Tag] = true;
-  cloneableTags[errorTag] = cloneableTags[funcTag] =
-  cloneableTags[weakMapTag] = false;
+  var cloneableTags = {}
+  cloneableTags[argsTag] = cloneableTags[arrayTag] = cloneableTags[arrayBufferTag] = cloneableTags[
+    dataViewTag
+  ] = cloneableTags[boolTag] = cloneableTags[dateTag] = cloneableTags[float32Tag] = cloneableTags[
+    float64Tag
+  ] = cloneableTags[int8Tag] = cloneableTags[int16Tag] = cloneableTags[int32Tag] = cloneableTags[
+    mapTag
+  ] = cloneableTags[numberTag] = cloneableTags[objectTag] = cloneableTags[regexpTag] = cloneableTags[
+    setTag
+  ] = cloneableTags[stringTag] = cloneableTags[symbolTag] = cloneableTags[uint8Tag] = cloneableTags[
+    uint8ClampedTag
+  ] = cloneableTags[uint16Tag] = cloneableTags[uint32Tag] = true
+  cloneableTags[errorTag] = cloneableTags[funcTag] = cloneableTags[weakMapTag] = false
 
   /** Used to map Latin Unicode letters to basic Latin letters. */
   var deburredLetters = {
     // Latin-1 Supplement block.
-    '\xc0': 'A',  '\xc1': 'A', '\xc2': 'A', '\xc3': 'A', '\xc4': 'A', '\xc5': 'A',
-    '\xe0': 'a',  '\xe1': 'a', '\xe2': 'a', '\xe3': 'a', '\xe4': 'a', '\xe5': 'a',
-    '\xc7': 'C',  '\xe7': 'c',
-    '\xd0': 'D',  '\xf0': 'd',
-    '\xc8': 'E',  '\xc9': 'E', '\xca': 'E', '\xcb': 'E',
-    '\xe8': 'e',  '\xe9': 'e', '\xea': 'e', '\xeb': 'e',
-    '\xcc': 'I',  '\xcd': 'I', '\xce': 'I', '\xcf': 'I',
-    '\xec': 'i',  '\xed': 'i', '\xee': 'i', '\xef': 'i',
-    '\xd1': 'N',  '\xf1': 'n',
-    '\xd2': 'O',  '\xd3': 'O', '\xd4': 'O', '\xd5': 'O', '\xd6': 'O', '\xd8': 'O',
-    '\xf2': 'o',  '\xf3': 'o', '\xf4': 'o', '\xf5': 'o', '\xf6': 'o', '\xf8': 'o',
-    '\xd9': 'U',  '\xda': 'U', '\xdb': 'U', '\xdc': 'U',
-    '\xf9': 'u',  '\xfa': 'u', '\xfb': 'u', '\xfc': 'u',
-    '\xdd': 'Y',  '\xfd': 'y', '\xff': 'y',
-    '\xc6': 'Ae', '\xe6': 'ae',
-    '\xde': 'Th', '\xfe': 'th',
-    '\xdf': 'ss',
+    À: 'A',
+    Á: 'A',
+    Â: 'A',
+    Ã: 'A',
+    Ä: 'A',
+    Å: 'A',
+    à: 'a',
+    á: 'a',
+    â: 'a',
+    ã: 'a',
+    ä: 'a',
+    å: 'a',
+    Ç: 'C',
+    ç: 'c',
+    Ð: 'D',
+    ð: 'd',
+    È: 'E',
+    É: 'E',
+    Ê: 'E',
+    Ë: 'E',
+    è: 'e',
+    é: 'e',
+    ê: 'e',
+    ë: 'e',
+    Ì: 'I',
+    Í: 'I',
+    Î: 'I',
+    Ï: 'I',
+    ì: 'i',
+    í: 'i',
+    î: 'i',
+    ï: 'i',
+    Ñ: 'N',
+    ñ: 'n',
+    Ò: 'O',
+    Ó: 'O',
+    Ô: 'O',
+    Õ: 'O',
+    Ö: 'O',
+    Ø: 'O',
+    ò: 'o',
+    ó: 'o',
+    ô: 'o',
+    õ: 'o',
+    ö: 'o',
+    ø: 'o',
+    Ù: 'U',
+    Ú: 'U',
+    Û: 'U',
+    Ü: 'U',
+    ù: 'u',
+    ú: 'u',
+    û: 'u',
+    ü: 'u',
+    Ý: 'Y',
+    ý: 'y',
+    ÿ: 'y',
+    Æ: 'Ae',
+    æ: 'ae',
+    Þ: 'Th',
+    þ: 'th',
+    ß: 'ss',
     // Latin Extended-A block.
-    '\u0100': 'A',  '\u0102': 'A', '\u0104': 'A',
-    '\u0101': 'a',  '\u0103': 'a', '\u0105': 'a',
-    '\u0106': 'C',  '\u0108': 'C', '\u010a': 'C', '\u010c': 'C',
-    '\u0107': 'c',  '\u0109': 'c', '\u010b': 'c', '\u010d': 'c',
-    '\u010e': 'D',  '\u0110': 'D', '\u010f': 'd', '\u0111': 'd',
-    '\u0112': 'E',  '\u0114': 'E', '\u0116': 'E', '\u0118': 'E', '\u011a': 'E',
-    '\u0113': 'e',  '\u0115': 'e', '\u0117': 'e', '\u0119': 'e', '\u011b': 'e',
-    '\u011c': 'G',  '\u011e': 'G', '\u0120': 'G', '\u0122': 'G',
-    '\u011d': 'g',  '\u011f': 'g', '\u0121': 'g', '\u0123': 'g',
-    '\u0124': 'H',  '\u0126': 'H', '\u0125': 'h', '\u0127': 'h',
-    '\u0128': 'I',  '\u012a': 'I', '\u012c': 'I', '\u012e': 'I', '\u0130': 'I',
-    '\u0129': 'i',  '\u012b': 'i', '\u012d': 'i', '\u012f': 'i', '\u0131': 'i',
-    '\u0134': 'J',  '\u0135': 'j',
-    '\u0136': 'K',  '\u0137': 'k', '\u0138': 'k',
-    '\u0139': 'L',  '\u013b': 'L', '\u013d': 'L', '\u013f': 'L', '\u0141': 'L',
-    '\u013a': 'l',  '\u013c': 'l', '\u013e': 'l', '\u0140': 'l', '\u0142': 'l',
-    '\u0143': 'N',  '\u0145': 'N', '\u0147': 'N', '\u014a': 'N',
-    '\u0144': 'n',  '\u0146': 'n', '\u0148': 'n', '\u014b': 'n',
-    '\u014c': 'O',  '\u014e': 'O', '\u0150': 'O',
-    '\u014d': 'o',  '\u014f': 'o', '\u0151': 'o',
-    '\u0154': 'R',  '\u0156': 'R', '\u0158': 'R',
-    '\u0155': 'r',  '\u0157': 'r', '\u0159': 'r',
-    '\u015a': 'S',  '\u015c': 'S', '\u015e': 'S', '\u0160': 'S',
-    '\u015b': 's',  '\u015d': 's', '\u015f': 's', '\u0161': 's',
-    '\u0162': 'T',  '\u0164': 'T', '\u0166': 'T',
-    '\u0163': 't',  '\u0165': 't', '\u0167': 't',
-    '\u0168': 'U',  '\u016a': 'U', '\u016c': 'U', '\u016e': 'U', '\u0170': 'U', '\u0172': 'U',
-    '\u0169': 'u',  '\u016b': 'u', '\u016d': 'u', '\u016f': 'u', '\u0171': 'u', '\u0173': 'u',
-    '\u0174': 'W',  '\u0175': 'w',
-    '\u0176': 'Y',  '\u0177': 'y', '\u0178': 'Y',
-    '\u0179': 'Z',  '\u017b': 'Z', '\u017d': 'Z',
-    '\u017a': 'z',  '\u017c': 'z', '\u017e': 'z',
-    '\u0132': 'IJ', '\u0133': 'ij',
-    '\u0152': 'Oe', '\u0153': 'oe',
-    '\u0149': "'n", '\u017f': 's'
-  };
+    Ā: 'A',
+    Ă: 'A',
+    Ą: 'A',
+    ā: 'a',
+    ă: 'a',
+    ą: 'a',
+    Ć: 'C',
+    Ĉ: 'C',
+    Ċ: 'C',
+    Č: 'C',
+    ć: 'c',
+    ĉ: 'c',
+    ċ: 'c',
+    č: 'c',
+    Ď: 'D',
+    Đ: 'D',
+    ď: 'd',
+    đ: 'd',
+    Ē: 'E',
+    Ĕ: 'E',
+    Ė: 'E',
+    Ę: 'E',
+    Ě: 'E',
+    ē: 'e',
+    ĕ: 'e',
+    ė: 'e',
+    ę: 'e',
+    ě: 'e',
+    Ĝ: 'G',
+    Ğ: 'G',
+    Ġ: 'G',
+    Ģ: 'G',
+    ĝ: 'g',
+    ğ: 'g',
+    ġ: 'g',
+    ģ: 'g',
+    Ĥ: 'H',
+    Ħ: 'H',
+    ĥ: 'h',
+    ħ: 'h',
+    Ĩ: 'I',
+    Ī: 'I',
+    Ĭ: 'I',
+    Į: 'I',
+    İ: 'I',
+    ĩ: 'i',
+    ī: 'i',
+    ĭ: 'i',
+    į: 'i',
+    ı: 'i',
+    Ĵ: 'J',
+    ĵ: 'j',
+    Ķ: 'K',
+    ķ: 'k',
+    ĸ: 'k',
+    Ĺ: 'L',
+    Ļ: 'L',
+    Ľ: 'L',
+    Ŀ: 'L',
+    Ł: 'L',
+    ĺ: 'l',
+    ļ: 'l',
+    ľ: 'l',
+    ŀ: 'l',
+    ł: 'l',
+    Ń: 'N',
+    Ņ: 'N',
+    Ň: 'N',
+    Ŋ: 'N',
+    ń: 'n',
+    ņ: 'n',
+    ň: 'n',
+    ŋ: 'n',
+    Ō: 'O',
+    Ŏ: 'O',
+    Ő: 'O',
+    ō: 'o',
+    ŏ: 'o',
+    ő: 'o',
+    Ŕ: 'R',
+    Ŗ: 'R',
+    Ř: 'R',
+    ŕ: 'r',
+    ŗ: 'r',
+    ř: 'r',
+    Ś: 'S',
+    Ŝ: 'S',
+    Ş: 'S',
+    Š: 'S',
+    ś: 's',
+    ŝ: 's',
+    ş: 's',
+    š: 's',
+    Ţ: 'T',
+    Ť: 'T',
+    Ŧ: 'T',
+    ţ: 't',
+    ť: 't',
+    ŧ: 't',
+    Ũ: 'U',
+    Ū: 'U',
+    Ŭ: 'U',
+    Ů: 'U',
+    Ű: 'U',
+    Ų: 'U',
+    ũ: 'u',
+    ū: 'u',
+    ŭ: 'u',
+    ů: 'u',
+    ű: 'u',
+    ų: 'u',
+    Ŵ: 'W',
+    ŵ: 'w',
+    Ŷ: 'Y',
+    ŷ: 'y',
+    Ÿ: 'Y',
+    Ź: 'Z',
+    Ż: 'Z',
+    Ž: 'Z',
+    ź: 'z',
+    ż: 'z',
+    ž: 'z',
+    Ĳ: 'IJ',
+    ĳ: 'ij',
+    Œ: 'Oe',
+    œ: 'oe',
+    ŉ: "'n",
+    ſ: 's'
+  }
 
   /** Used to map characters to HTML entities. */
   var htmlEscapes = {
@@ -388,7 +553,7 @@
     '>': '&gt;',
     '"': '&quot;',
     "'": '&#39;'
-  };
+  }
 
   /** Used to map HTML entities to characters. */
   var htmlUnescapes = {
@@ -397,7 +562,7 @@
     '&gt;': '>',
     '&quot;': '"',
     '&#39;': "'"
-  };
+  }
 
   /** Used to escape characters for inclusion in compiled string literals. */
   var stringEscapes = {
@@ -407,47 +572,47 @@
     '\r': 'r',
     '\u2028': 'u2028',
     '\u2029': 'u2029'
-  };
+  }
 
   /** Built-in method references without a dependency on `root`. */
   var freeParseFloat = parseFloat,
-      freeParseInt = parseInt;
+    freeParseInt = parseInt
 
   /** Detect free variable `global` from Node.js. */
-  var freeGlobal = typeof global == 'object' && global && global.Object === Object && global;
+  var freeGlobal = typeof global == 'object' && global && global.Object === Object && global
 
   /** Detect free variable `self`. */
-  var freeSelf = typeof self == 'object' && self && self.Object === Object && self;
+  var freeSelf = typeof self == 'object' && self && self.Object === Object && self
 
   /** Used as a reference to the global object. */
-  var root = freeGlobal || freeSelf || Function('return this')();
+  var root = freeGlobal || freeSelf || Function('return this')()
 
   /** Detect free variable `exports`. */
-  var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports;
+  var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports
 
   /** Detect free variable `module`. */
-  var freeModule = freeExports && typeof module == 'object' && module && !module.nodeType && module;
+  var freeModule = freeExports && typeof module == 'object' && module && !module.nodeType && module
 
   /** Detect the popular CommonJS extension `module.exports`. */
-  var moduleExports = freeModule && freeModule.exports === freeExports;
+  var moduleExports = freeModule && freeModule.exports === freeExports
 
   /** Detect free variable `process` from Node.js. */
-  var freeProcess = moduleExports && freeGlobal.process;
+  var freeProcess = moduleExports && freeGlobal.process
 
   /** Used to access faster Node.js helpers. */
   var nodeUtil = (function() {
     try {
-      return freeProcess && freeProcess.binding && freeProcess.binding('util');
+      return freeProcess && freeProcess.binding && freeProcess.binding('util')
     } catch (e) {}
-  }());
+  })()
 
   /* Node.js helper references. */
   var nodeIsArrayBuffer = nodeUtil && nodeUtil.isArrayBuffer,
-      nodeIsDate = nodeUtil && nodeUtil.isDate,
-      nodeIsMap = nodeUtil && nodeUtil.isMap,
-      nodeIsRegExp = nodeUtil && nodeUtil.isRegExp,
-      nodeIsSet = nodeUtil && nodeUtil.isSet,
-      nodeIsTypedArray = nodeUtil && nodeUtil.isTypedArray;
+    nodeIsDate = nodeUtil && nodeUtil.isDate,
+    nodeIsMap = nodeUtil && nodeUtil.isMap,
+    nodeIsRegExp = nodeUtil && nodeUtil.isRegExp,
+    nodeIsSet = nodeUtil && nodeUtil.isSet,
+    nodeIsTypedArray = nodeUtil && nodeUtil.isTypedArray
 
   /*--------------------------------------------------------------------------*/
 
@@ -461,8 +626,8 @@
    */
   function addMapEntry(map, pair) {
     // Don't return `map.set` because it's not chainable in IE 11.
-    map.set(pair[0], pair[1]);
-    return map;
+    map.set(pair[0], pair[1])
+    return map
   }
 
   /**
@@ -475,8 +640,8 @@
    */
   function addSetEntry(set, value) {
     // Don't return `set.add` because it's not chainable in IE 11.
-    set.add(value);
-    return set;
+    set.add(value)
+    return set
   }
 
   /**
@@ -491,12 +656,16 @@
    */
   function apply(func, thisArg, args) {
     switch (args.length) {
-      case 0: return func.call(thisArg);
-      case 1: return func.call(thisArg, args[0]);
-      case 2: return func.call(thisArg, args[0], args[1]);
-      case 3: return func.call(thisArg, args[0], args[1], args[2]);
+      case 0:
+        return func.call(thisArg)
+      case 1:
+        return func.call(thisArg, args[0])
+      case 2:
+        return func.call(thisArg, args[0], args[1])
+      case 3:
+        return func.call(thisArg, args[0], args[1], args[2])
     }
-    return func.apply(thisArg, args);
+    return func.apply(thisArg, args)
   }
 
   /**
@@ -511,13 +680,13 @@
    */
   function arrayAggregator(array, setter, iteratee, accumulator) {
     var index = -1,
-        length = array == null ? 0 : array.length;
+      length = array == null ? 0 : array.length
 
     while (++index < length) {
-      var value = array[index];
-      setter(accumulator, value, iteratee(value), array);
+      var value = array[index]
+      setter(accumulator, value, iteratee(value), array)
     }
-    return accumulator;
+    return accumulator
   }
 
   /**
@@ -531,14 +700,14 @@
    */
   function arrayEach(array, iteratee) {
     var index = -1,
-        length = array == null ? 0 : array.length;
+      length = array == null ? 0 : array.length
 
     while (++index < length) {
       if (iteratee(array[index], index, array) === false) {
-        break;
+        break
       }
     }
-    return array;
+    return array
   }
 
   /**
@@ -551,14 +720,14 @@
    * @returns {Array} Returns `array`.
    */
   function arrayEachRight(array, iteratee) {
-    var length = array == null ? 0 : array.length;
+    var length = array == null ? 0 : array.length
 
     while (length--) {
       if (iteratee(array[length], length, array) === false) {
-        break;
+        break
       }
     }
-    return array;
+    return array
   }
 
   /**
@@ -573,14 +742,14 @@
    */
   function arrayEvery(array, predicate) {
     var index = -1,
-        length = array == null ? 0 : array.length;
+      length = array == null ? 0 : array.length
 
     while (++index < length) {
       if (!predicate(array[index], index, array)) {
-        return false;
+        return false
       }
     }
-    return true;
+    return true
   }
 
   /**
@@ -594,17 +763,17 @@
    */
   function arrayFilter(array, predicate) {
     var index = -1,
-        length = array == null ? 0 : array.length,
-        resIndex = 0,
-        result = [];
+      length = array == null ? 0 : array.length,
+      resIndex = 0,
+      result = []
 
     while (++index < length) {
-      var value = array[index];
+      var value = array[index]
       if (predicate(value, index, array)) {
-        result[resIndex++] = value;
+        result[resIndex++] = value
       }
     }
-    return result;
+    return result
   }
 
   /**
@@ -617,8 +786,8 @@
    * @returns {boolean} Returns `true` if `target` is found, else `false`.
    */
   function arrayIncludes(array, value) {
-    var length = array == null ? 0 : array.length;
-    return !!length && baseIndexOf(array, value, 0) > -1;
+    var length = array == null ? 0 : array.length
+    return !!length && baseIndexOf(array, value, 0) > -1
   }
 
   /**
@@ -632,14 +801,14 @@
    */
   function arrayIncludesWith(array, value, comparator) {
     var index = -1,
-        length = array == null ? 0 : array.length;
+      length = array == null ? 0 : array.length
 
     while (++index < length) {
       if (comparator(value, array[index])) {
-        return true;
+        return true
       }
     }
-    return false;
+    return false
   }
 
   /**
@@ -653,13 +822,13 @@
    */
   function arrayMap(array, iteratee) {
     var index = -1,
-        length = array == null ? 0 : array.length,
-        result = Array(length);
+      length = array == null ? 0 : array.length,
+      result = Array(length)
 
     while (++index < length) {
-      result[index] = iteratee(array[index], index, array);
+      result[index] = iteratee(array[index], index, array)
     }
-    return result;
+    return result
   }
 
   /**
@@ -672,13 +841,13 @@
    */
   function arrayPush(array, values) {
     var index = -1,
-        length = values.length,
-        offset = array.length;
+      length = values.length,
+      offset = array.length
 
     while (++index < length) {
-      array[offset + index] = values[index];
+      array[offset + index] = values[index]
     }
-    return array;
+    return array
   }
 
   /**
@@ -695,15 +864,15 @@
    */
   function arrayReduce(array, iteratee, accumulator, initAccum) {
     var index = -1,
-        length = array == null ? 0 : array.length;
+      length = array == null ? 0 : array.length
 
     if (initAccum && length) {
-      accumulator = array[++index];
+      accumulator = array[++index]
     }
     while (++index < length) {
-      accumulator = iteratee(accumulator, array[index], index, array);
+      accumulator = iteratee(accumulator, array[index], index, array)
     }
-    return accumulator;
+    return accumulator
   }
 
   /**
@@ -719,14 +888,14 @@
    * @returns {*} Returns the accumulated value.
    */
   function arrayReduceRight(array, iteratee, accumulator, initAccum) {
-    var length = array == null ? 0 : array.length;
+    var length = array == null ? 0 : array.length
     if (initAccum && length) {
-      accumulator = array[--length];
+      accumulator = array[--length]
     }
     while (length--) {
-      accumulator = iteratee(accumulator, array[length], length, array);
+      accumulator = iteratee(accumulator, array[length], length, array)
     }
-    return accumulator;
+    return accumulator
   }
 
   /**
@@ -741,14 +910,14 @@
    */
   function arraySome(array, predicate) {
     var index = -1,
-        length = array == null ? 0 : array.length;
+      length = array == null ? 0 : array.length
 
     while (++index < length) {
       if (predicate(array[index], index, array)) {
-        return true;
+        return true
       }
     }
-    return false;
+    return false
   }
 
   /**
@@ -758,7 +927,7 @@
    * @param {string} string The string inspect.
    * @returns {number} Returns the string size.
    */
-  var asciiSize = baseProperty('length');
+  var asciiSize = baseProperty('length')
 
   /**
    * Converts an ASCII `string` to an array.
@@ -768,7 +937,7 @@
    * @returns {Array} Returns the converted array.
    */
   function asciiToArray(string) {
-    return string.split('');
+    return string.split('')
   }
 
   /**
@@ -779,7 +948,7 @@
    * @returns {Array} Returns the words of `string`.
    */
   function asciiWords(string) {
-    return string.match(reAsciiWord) || [];
+    return string.match(reAsciiWord) || []
   }
 
   /**
@@ -794,14 +963,14 @@
    * @returns {*} Returns the found element or its key, else `undefined`.
    */
   function baseFindKey(collection, predicate, eachFunc) {
-    var result;
+    var result
     eachFunc(collection, function(value, key, collection) {
       if (predicate(value, key, collection)) {
-        result = key;
-        return false;
+        result = key
+        return false
       }
-    });
-    return result;
+    })
+    return result
   }
 
   /**
@@ -817,14 +986,14 @@
    */
   function baseFindIndex(array, predicate, fromIndex, fromRight) {
     var length = array.length,
-        index = fromIndex + (fromRight ? 1 : -1);
+      index = fromIndex + (fromRight ? 1 : -1)
 
-    while ((fromRight ? index-- : ++index < length)) {
+    while (fromRight ? index-- : ++index < length) {
       if (predicate(array[index], index, array)) {
-        return index;
+        return index
       }
     }
-    return -1;
+    return -1
   }
 
   /**
@@ -837,9 +1006,7 @@
    * @returns {number} Returns the index of the matched value, else `-1`.
    */
   function baseIndexOf(array, value, fromIndex) {
-    return value === value
-      ? strictIndexOf(array, value, fromIndex)
-      : baseFindIndex(array, baseIsNaN, fromIndex);
+    return value === value ? strictIndexOf(array, value, fromIndex) : baseFindIndex(array, baseIsNaN, fromIndex)
   }
 
   /**
@@ -854,14 +1021,14 @@
    */
   function baseIndexOfWith(array, value, fromIndex, comparator) {
     var index = fromIndex - 1,
-        length = array.length;
+      length = array.length
 
     while (++index < length) {
       if (comparator(array[index], value)) {
-        return index;
+        return index
       }
     }
-    return -1;
+    return -1
   }
 
   /**
@@ -872,7 +1039,7 @@
    * @returns {boolean} Returns `true` if `value` is `NaN`, else `false`.
    */
   function baseIsNaN(value) {
-    return value !== value;
+    return value !== value
   }
 
   /**
@@ -885,8 +1052,8 @@
    * @returns {number} Returns the mean.
    */
   function baseMean(array, iteratee) {
-    var length = array == null ? 0 : array.length;
-    return length ? (baseSum(array, iteratee) / length) : NAN;
+    var length = array == null ? 0 : array.length
+    return length ? baseSum(array, iteratee) / length : NAN
   }
 
   /**
@@ -898,8 +1065,8 @@
    */
   function baseProperty(key) {
     return function(object) {
-      return object == null ? undefined : object[key];
-    };
+      return object == null ? undefined : object[key]
+    }
   }
 
   /**
@@ -911,8 +1078,8 @@
    */
   function basePropertyOf(object) {
     return function(key) {
-      return object == null ? undefined : object[key];
-    };
+      return object == null ? undefined : object[key]
+    }
   }
 
   /**
@@ -930,11 +1097,9 @@
    */
   function baseReduce(collection, iteratee, accumulator, initAccum, eachFunc) {
     eachFunc(collection, function(value, index, collection) {
-      accumulator = initAccum
-        ? (initAccum = false, value)
-        : iteratee(accumulator, value, index, collection);
-    });
-    return accumulator;
+      accumulator = initAccum ? ((initAccum = false), value) : iteratee(accumulator, value, index, collection)
+    })
+    return accumulator
   }
 
   /**
@@ -948,13 +1113,13 @@
    * @returns {Array} Returns `array`.
    */
   function baseSortBy(array, comparer) {
-    var length = array.length;
+    var length = array.length
 
-    array.sort(comparer);
+    array.sort(comparer)
     while (length--) {
-      array[length] = array[length].value;
+      array[length] = array[length].value
     }
-    return array;
+    return array
   }
 
   /**
@@ -968,16 +1133,16 @@
    */
   function baseSum(array, iteratee) {
     var result,
-        index = -1,
-        length = array.length;
+      index = -1,
+      length = array.length
 
     while (++index < length) {
-      var current = iteratee(array[index]);
+      var current = iteratee(array[index])
       if (current !== undefined) {
-        result = result === undefined ? current : (result + current);
+        result = result === undefined ? current : result + current
       }
     }
-    return result;
+    return result
   }
 
   /**
@@ -991,12 +1156,12 @@
    */
   function baseTimes(n, iteratee) {
     var index = -1,
-        result = Array(n);
+      result = Array(n)
 
     while (++index < n) {
-      result[index] = iteratee(index);
+      result[index] = iteratee(index)
     }
-    return result;
+    return result
   }
 
   /**
@@ -1010,8 +1175,8 @@
    */
   function baseToPairs(object, props) {
     return arrayMap(props, function(key) {
-      return [key, object[key]];
-    });
+      return [key, object[key]]
+    })
   }
 
   /**
@@ -1023,8 +1188,8 @@
    */
   function baseUnary(func) {
     return function(value) {
-      return func(value);
-    };
+      return func(value)
+    }
   }
 
   /**
@@ -1039,8 +1204,8 @@
    */
   function baseValues(object, props) {
     return arrayMap(props, function(key) {
-      return object[key];
-    });
+      return object[key]
+    })
   }
 
   /**
@@ -1052,7 +1217,7 @@
    * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
    */
   function cacheHas(cache, key) {
-    return cache.has(key);
+    return cache.has(key)
   }
 
   /**
@@ -1066,10 +1231,10 @@
    */
   function charsStartIndex(strSymbols, chrSymbols) {
     var index = -1,
-        length = strSymbols.length;
+      length = strSymbols.length
 
     while (++index < length && baseIndexOf(chrSymbols, strSymbols[index], 0) > -1) {}
-    return index;
+    return index
   }
 
   /**
@@ -1082,10 +1247,10 @@
    * @returns {number} Returns the index of the last unmatched string symbol.
    */
   function charsEndIndex(strSymbols, chrSymbols) {
-    var index = strSymbols.length;
+    var index = strSymbols.length
 
     while (index-- && baseIndexOf(chrSymbols, strSymbols[index], 0) > -1) {}
-    return index;
+    return index
   }
 
   /**
@@ -1098,14 +1263,14 @@
    */
   function countHolders(array, placeholder) {
     var length = array.length,
-        result = 0;
+      result = 0
 
     while (length--) {
       if (array[length] === placeholder) {
-        ++result;
+        ++result
       }
     }
-    return result;
+    return result
   }
 
   /**
@@ -1116,7 +1281,7 @@
    * @param {string} letter The matched letter to deburr.
    * @returns {string} Returns the deburred letter.
    */
-  var deburrLetter = basePropertyOf(deburredLetters);
+  var deburrLetter = basePropertyOf(deburredLetters)
 
   /**
    * Used by `_.escape` to convert characters to HTML entities.
@@ -1125,7 +1290,7 @@
    * @param {string} chr The matched character to escape.
    * @returns {string} Returns the escaped character.
    */
-  var escapeHtmlChar = basePropertyOf(htmlEscapes);
+  var escapeHtmlChar = basePropertyOf(htmlEscapes)
 
   /**
    * Used by `_.template` to escape characters for inclusion in compiled string literals.
@@ -1135,7 +1300,7 @@
    * @returns {string} Returns the escaped character.
    */
   function escapeStringChar(chr) {
-    return '\\' + stringEscapes[chr];
+    return '\\' + stringEscapes[chr]
   }
 
   /**
@@ -1147,7 +1312,7 @@
    * @returns {*} Returns the property value.
    */
   function getValue(object, key) {
-    return object == null ? undefined : object[key];
+    return object == null ? undefined : object[key]
   }
 
   /**
@@ -1158,7 +1323,7 @@
    * @returns {boolean} Returns `true` if a symbol is found, else `false`.
    */
   function hasUnicode(string) {
-    return reHasUnicode.test(string);
+    return reHasUnicode.test(string)
   }
 
   /**
@@ -1169,7 +1334,7 @@
    * @returns {boolean} Returns `true` if a word is found, else `false`.
    */
   function hasUnicodeWord(string) {
-    return reHasUnicodeWord.test(string);
+    return reHasUnicodeWord.test(string)
   }
 
   /**
@@ -1181,12 +1346,12 @@
    */
   function iteratorToArray(iterator) {
     var data,
-        result = [];
+      result = []
 
     while (!(data = iterator.next()).done) {
-      result.push(data.value);
+      result.push(data.value)
     }
-    return result;
+    return result
   }
 
   /**
@@ -1198,12 +1363,12 @@
    */
   function mapToArray(map) {
     var index = -1,
-        result = Array(map.size);
+      result = Array(map.size)
 
     map.forEach(function(value, key) {
-      result[++index] = [key, value];
-    });
-    return result;
+      result[++index] = [key, value]
+    })
+    return result
   }
 
   /**
@@ -1216,8 +1381,8 @@
    */
   function overArg(func, transform) {
     return function(arg) {
-      return func(transform(arg));
-    };
+      return func(transform(arg))
+    }
   }
 
   /**
@@ -1231,18 +1396,18 @@
    */
   function replaceHolders(array, placeholder) {
     var index = -1,
-        length = array.length,
-        resIndex = 0,
-        result = [];
+      length = array.length,
+      resIndex = 0,
+      result = []
 
     while (++index < length) {
-      var value = array[index];
+      var value = array[index]
       if (value === placeholder || value === PLACEHOLDER) {
-        array[index] = PLACEHOLDER;
-        result[resIndex++] = index;
+        array[index] = PLACEHOLDER
+        result[resIndex++] = index
       }
     }
-    return result;
+    return result
   }
 
   /**
@@ -1254,12 +1419,12 @@
    */
   function setToArray(set) {
     var index = -1,
-        result = Array(set.size);
+      result = Array(set.size)
 
     set.forEach(function(value) {
-      result[++index] = value;
-    });
-    return result;
+      result[++index] = value
+    })
+    return result
   }
 
   /**
@@ -1271,12 +1436,12 @@
    */
   function setToPairs(set) {
     var index = -1,
-        result = Array(set.size);
+      result = Array(set.size)
 
     set.forEach(function(value) {
-      result[++index] = [value, value];
-    });
-    return result;
+      result[++index] = [value, value]
+    })
+    return result
   }
 
   /**
@@ -1291,14 +1456,14 @@
    */
   function strictIndexOf(array, value, fromIndex) {
     var index = fromIndex - 1,
-        length = array.length;
+      length = array.length
 
     while (++index < length) {
       if (array[index] === value) {
-        return index;
+        return index
       }
     }
-    return -1;
+    return -1
   }
 
   /**
@@ -1312,13 +1477,13 @@
    * @returns {number} Returns the index of the matched value, else `-1`.
    */
   function strictLastIndexOf(array, value, fromIndex) {
-    var index = fromIndex + 1;
+    var index = fromIndex + 1
     while (index--) {
       if (array[index] === value) {
-        return index;
+        return index
       }
     }
-    return index;
+    return index
   }
 
   /**
@@ -1329,9 +1494,7 @@
    * @returns {number} Returns the string size.
    */
   function stringSize(string) {
-    return hasUnicode(string)
-      ? unicodeSize(string)
-      : asciiSize(string);
+    return hasUnicode(string) ? unicodeSize(string) : asciiSize(string)
   }
 
   /**
@@ -1342,9 +1505,7 @@
    * @returns {Array} Returns the converted array.
    */
   function stringToArray(string) {
-    return hasUnicode(string)
-      ? unicodeToArray(string)
-      : asciiToArray(string);
+    return hasUnicode(string) ? unicodeToArray(string) : asciiToArray(string)
   }
 
   /**
@@ -1354,7 +1515,7 @@
    * @param {string} chr The matched character to unescape.
    * @returns {string} Returns the unescaped character.
    */
-  var unescapeHtmlChar = basePropertyOf(htmlUnescapes);
+  var unescapeHtmlChar = basePropertyOf(htmlUnescapes)
 
   /**
    * Gets the size of a Unicode `string`.
@@ -1364,11 +1525,11 @@
    * @returns {number} Returns the string size.
    */
   function unicodeSize(string) {
-    var result = reUnicode.lastIndex = 0;
+    var result = (reUnicode.lastIndex = 0)
     while (reUnicode.test(string)) {
-      ++result;
+      ++result
     }
-    return result;
+    return result
   }
 
   /**
@@ -1379,7 +1540,7 @@
    * @returns {Array} Returns the converted array.
    */
   function unicodeToArray(string) {
-    return string.match(reUnicode) || [];
+    return string.match(reUnicode) || []
   }
 
   /**
@@ -1390,7 +1551,7 @@
    * @returns {Array} Returns the words of `string`.
    */
   function unicodeWords(string) {
-    return string.match(reUnicodeWord) || [];
+    return string.match(reUnicodeWord) || []
   }
 
   /*--------------------------------------------------------------------------*/
@@ -1424,128 +1585,132 @@
    * // Create a suped-up `defer` in Node.js.
    * var defer = _.runInContext({ 'setTimeout': setImmediate }).defer;
    */
-  var runInContext = (function runInContext(context) {
-    context = context == null ? root : _.defaults(root.Object(), context, _.pick(root, contextProps));
+  var runInContext = function runInContext(context) {
+    context = context == null ? root : _.defaults(root.Object(), context, _.pick(root, contextProps))
 
     /** Built-in constructor references. */
     var Array = context.Array,
-        Date = context.Date,
-        Error = context.Error,
-        Function = context.Function,
-        Math = context.Math,
-        Object = context.Object,
-        RegExp = context.RegExp,
-        String = context.String,
-        TypeError = context.TypeError;
+      Date = context.Date,
+      Error = context.Error,
+      Function = context.Function,
+      Math = context.Math,
+      Object = context.Object,
+      RegExp = context.RegExp,
+      String = context.String,
+      TypeError = context.TypeError
 
     /** Used for built-in method references. */
     var arrayProto = Array.prototype,
-        funcProto = Function.prototype,
-        objectProto = Object.prototype;
+      funcProto = Function.prototype,
+      objectProto = Object.prototype
 
     /** Used to detect overreaching core-js shims. */
-    var coreJsData = context['__core-js_shared__'];
+    var coreJsData = context['__core-js_shared__']
 
     /** Used to resolve the decompiled source of functions. */
-    var funcToString = funcProto.toString;
+    var funcToString = funcProto.toString
 
     /** Used to check objects for own properties. */
-    var hasOwnProperty = objectProto.hasOwnProperty;
+    var hasOwnProperty = objectProto.hasOwnProperty
 
     /** Used to generate unique IDs. */
-    var idCounter = 0;
+    var idCounter = 0
 
     /** Used to detect methods masquerading as native. */
     var maskSrcKey = (function() {
-      var uid = /[^.]+$/.exec(coreJsData && coreJsData.keys && coreJsData.keys.IE_PROTO || '');
-      return uid ? ('Symbol(src)_1.' + uid) : '';
-    }());
+      var uid = /[^.]+$/.exec((coreJsData && coreJsData.keys && coreJsData.keys.IE_PROTO) || '')
+      return uid ? 'Symbol(src)_1.' + uid : ''
+    })()
 
     /**
      * Used to resolve the
      * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
      * of values.
      */
-    var nativeObjectToString = objectProto.toString;
+    var nativeObjectToString = objectProto.toString
 
     /** Used to infer the `Object` constructor. */
-    var objectCtorString = funcToString.call(Object);
+    var objectCtorString = funcToString.call(Object)
 
     /** Used to restore the original `_` reference in `_.noConflict`. */
-    var oldDash = root._;
+    var oldDash = root._
 
     /** Used to detect if a method is native. */
-    var reIsNative = RegExp('^' +
-      funcToString.call(hasOwnProperty).replace(reRegExpChar, '\\$&')
-      .replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') + '$'
-    );
+    var reIsNative = RegExp(
+      '^' +
+        funcToString
+          .call(hasOwnProperty)
+          .replace(reRegExpChar, '\\$&')
+          .replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') +
+        '$'
+    )
 
     /** Built-in value references. */
     var Buffer = moduleExports ? context.Buffer : undefined,
-        Symbol = context.Symbol,
-        Uint8Array = context.Uint8Array,
-        allocUnsafe = Buffer ? Buffer.allocUnsafe : undefined,
-        getPrototype = overArg(Object.getPrototypeOf, Object),
-        objectCreate = Object.create,
-        propertyIsEnumerable = objectProto.propertyIsEnumerable,
-        splice = arrayProto.splice,
-        spreadableSymbol = Symbol ? Symbol.isConcatSpreadable : undefined,
-        symIterator = Symbol ? Symbol.iterator : undefined,
-        symToStringTag = Symbol ? Symbol.toStringTag : undefined;
+      Symbol = context.Symbol,
+      Uint8Array = context.Uint8Array,
+      allocUnsafe = Buffer ? Buffer.allocUnsafe : undefined,
+      getPrototype = overArg(Object.getPrototypeOf, Object),
+      objectCreate = Object.create,
+      propertyIsEnumerable = objectProto.propertyIsEnumerable,
+      splice = arrayProto.splice,
+      spreadableSymbol = Symbol ? Symbol.isConcatSpreadable : undefined,
+      symIterator = Symbol ? Symbol.iterator : undefined,
+      symToStringTag = Symbol ? Symbol.toStringTag : undefined
 
     var defineProperty = (function() {
       try {
-        var func = getNative(Object, 'defineProperty');
-        func({}, '', {});
-        return func;
+        var func = getNative(Object, 'defineProperty')
+        func({}, '', {})
+        return func
       } catch (e) {}
-    }());
+    })()
 
     /** Mocked built-ins. */
     var ctxClearTimeout = context.clearTimeout !== root.clearTimeout && context.clearTimeout,
-        ctxNow = Date && Date.now !== root.Date.now && Date.now,
-        ctxSetTimeout = context.setTimeout !== root.setTimeout && context.setTimeout;
+      ctxNow = Date && Date.now !== root.Date.now && Date.now,
+      ctxSetTimeout = context.setTimeout !== root.setTimeout && context.setTimeout
 
     /* Built-in method references for those with the same name as other `lodash` methods. */
     var nativeCeil = Math.ceil,
-        nativeFloor = Math.floor,
-        nativeGetSymbols = Object.getOwnPropertySymbols,
-        nativeIsBuffer = Buffer ? Buffer.isBuffer : undefined,
-        nativeIsFinite = context.isFinite,
-        nativeJoin = arrayProto.join,
-        nativeKeys = overArg(Object.keys, Object),
-        nativeMax = Math.max,
-        nativeMin = Math.min,
-        nativeNow = Date.now,
-        nativeParseInt = context.parseInt,
-        nativeRandom = Math.random,
-        nativeReverse = arrayProto.reverse;
+      nativeFloor = Math.floor,
+      nativeGetSymbols = Object.getOwnPropertySymbols,
+      nativeIsBuffer = Buffer ? Buffer.isBuffer : undefined,
+      nativeIsFinite = context.isFinite,
+      nativeJoin = arrayProto.join,
+      nativeKeys = overArg(Object.keys, Object),
+      nativeMax = Math.max,
+      nativeMin = Math.min,
+      nativeNow = Date.now,
+      nativeParseInt = context.parseInt,
+      nativeRandom = Math.random,
+      nativeReverse = arrayProto.reverse
 
     /* Built-in method references that are verified to be native. */
     var DataView = getNative(context, 'DataView'),
-        Map = getNative(context, 'Map'),
-        Promise = getNative(context, 'Promise'),
-        Set = getNative(context, 'Set'),
-        WeakMap = getNative(context, 'WeakMap'),
-        nativeCreate = getNative(Object, 'create');
+      Map = getNative(context, 'Map'),
+      Promise = getNative(context, 'Promise'),
+      Set = getNative(context, 'Set'),
+      WeakMap = getNative(context, 'WeakMap'),
+      nativeCreate = getNative(Object, 'create')
 
     /** Used to store function metadata. */
-    var metaMap = WeakMap && new WeakMap;
+    var metaMap = WeakMap && new WeakMap()
 
     /** Used to lookup unminified function names. */
-    var realNames = {};
+    var realNames = {}
 
     /** Used to detect maps, sets, and weakmaps. */
     var dataViewCtorString = toSource(DataView),
-        mapCtorString = toSource(Map),
-        promiseCtorString = toSource(Promise),
-        setCtorString = toSource(Set),
-        weakMapCtorString = toSource(WeakMap);
+      mapCtorString = toSource(Map),
+      promiseCtorString = toSource(Promise),
+      setCtorString = toSource(Set),
+      weakMapCtorString = toSource(WeakMap)
 
     /** Used to convert symbols to primitives and strings. */
     var symbolProto = Symbol ? Symbol.prototype : undefined,
-        symbolValueOf = symbolProto ? symbolProto.valueOf : undefined,
-        symbolToString = symbolProto ? symbolProto.toString : undefined;
+      symbolValueOf = symbolProto ? symbolProto.valueOf : undefined,
+      symbolToString = symbolProto ? symbolProto.toString : undefined
 
     /*------------------------------------------------------------------------*/
 
@@ -1669,13 +1834,13 @@
     function lodash(value) {
       if (isObjectLike(value) && !isArray(value) && !(value instanceof LazyWrapper)) {
         if (value instanceof LodashWrapper) {
-          return value;
+          return value
         }
         if (hasOwnProperty.call(value, '__wrapped__')) {
-          return wrapperClone(value);
+          return wrapperClone(value)
         }
       }
-      return new LodashWrapper(value);
+      return new LodashWrapper(value)
     }
 
     /**
@@ -1690,17 +1855,17 @@
       function object() {}
       return function(proto) {
         if (!isObject(proto)) {
-          return {};
+          return {}
         }
         if (objectCreate) {
-          return objectCreate(proto);
+          return objectCreate(proto)
         }
-        object.prototype = proto;
-        var result = new object;
-        object.prototype = undefined;
-        return result;
-      };
-    }());
+        object.prototype = proto
+        var result = new object()
+        object.prototype = undefined
+        return result
+      }
+    })()
 
     /**
      * The function whose prototype chain sequence wrappers inherit from.
@@ -1719,11 +1884,11 @@
      * @param {boolean} [chainAll] Enable explicit method chain sequences.
      */
     function LodashWrapper(value, chainAll) {
-      this.__wrapped__ = value;
-      this.__actions__ = [];
-      this.__chain__ = !!chainAll;
-      this.__index__ = 0;
-      this.__values__ = undefined;
+      this.__wrapped__ = value
+      this.__actions__ = []
+      this.__chain__ = !!chainAll
+      this.__index__ = 0
+      this.__values__ = undefined
     }
 
     /**
@@ -1736,14 +1901,13 @@
      * @type {Object}
      */
     lodash.templateSettings = {
-
       /**
        * Used to detect `data` property values to be HTML-escaped.
        *
        * @memberOf _.templateSettings
        * @type {RegExp}
        */
-      'escape': reEscape,
+      escape: reEscape,
 
       /**
        * Used to detect code to be evaluated.
@@ -1751,7 +1915,7 @@
        * @memberOf _.templateSettings
        * @type {RegExp}
        */
-      'evaluate': reEvaluate,
+      evaluate: reEvaluate,
 
       /**
        * Used to detect `data` property values to inject.
@@ -1759,7 +1923,7 @@
        * @memberOf _.templateSettings
        * @type {RegExp}
        */
-      'interpolate': reInterpolate,
+      interpolate: reInterpolate,
 
       /**
        * Used to reference the data object in the template text.
@@ -1767,7 +1931,7 @@
        * @memberOf _.templateSettings
        * @type {string}
        */
-      'variable': '',
+      variable: '',
 
       /**
        * Used to import variables into the compiled template.
@@ -1775,24 +1939,23 @@
        * @memberOf _.templateSettings
        * @type {Object}
        */
-      'imports': {
-
+      imports: {
         /**
          * A reference to the `lodash` function.
          *
          * @memberOf _.templateSettings.imports
          * @type {Function}
          */
-        '_': lodash
+        _: lodash
       }
-    };
+    }
 
     // Ensure wrappers are instances of `baseLodash`.
-    lodash.prototype = baseLodash.prototype;
-    lodash.prototype.constructor = lodash;
+    lodash.prototype = baseLodash.prototype
+    lodash.prototype.constructor = lodash
 
-    LodashWrapper.prototype = baseCreate(baseLodash.prototype);
-    LodashWrapper.prototype.constructor = LodashWrapper;
+    LodashWrapper.prototype = baseCreate(baseLodash.prototype)
+    LodashWrapper.prototype.constructor = LodashWrapper
 
     /*------------------------------------------------------------------------*/
 
@@ -1804,13 +1967,13 @@
      * @param {*} value The value to wrap.
      */
     function LazyWrapper(value) {
-      this.__wrapped__ = value;
-      this.__actions__ = [];
-      this.__dir__ = 1;
-      this.__filtered__ = false;
-      this.__iteratees__ = [];
-      this.__takeCount__ = MAX_ARRAY_LENGTH;
-      this.__views__ = [];
+      this.__wrapped__ = value
+      this.__actions__ = []
+      this.__dir__ = 1
+      this.__filtered__ = false
+      this.__iteratees__ = []
+      this.__takeCount__ = MAX_ARRAY_LENGTH
+      this.__views__ = []
     }
 
     /**
@@ -1822,14 +1985,14 @@
      * @returns {Object} Returns the cloned `LazyWrapper` object.
      */
     function lazyClone() {
-      var result = new LazyWrapper(this.__wrapped__);
-      result.__actions__ = copyArray(this.__actions__);
-      result.__dir__ = this.__dir__;
-      result.__filtered__ = this.__filtered__;
-      result.__iteratees__ = copyArray(this.__iteratees__);
-      result.__takeCount__ = this.__takeCount__;
-      result.__views__ = copyArray(this.__views__);
-      return result;
+      var result = new LazyWrapper(this.__wrapped__)
+      result.__actions__ = copyArray(this.__actions__)
+      result.__dir__ = this.__dir__
+      result.__filtered__ = this.__filtered__
+      result.__iteratees__ = copyArray(this.__iteratees__)
+      result.__takeCount__ = this.__takeCount__
+      result.__views__ = copyArray(this.__views__)
+      return result
     }
 
     /**
@@ -1842,14 +2005,14 @@
      */
     function lazyReverse() {
       if (this.__filtered__) {
-        var result = new LazyWrapper(this);
-        result.__dir__ = -1;
-        result.__filtered__ = true;
+        var result = new LazyWrapper(this)
+        result.__dir__ = -1
+        result.__filtered__ = true
       } else {
-        result = this.clone();
-        result.__dir__ *= -1;
+        result = this.clone()
+        result.__dir__ *= -1
       }
-      return result;
+      return result
     }
 
     /**
@@ -1862,56 +2025,55 @@
      */
     function lazyValue() {
       var array = this.__wrapped__.value(),
-          dir = this.__dir__,
-          isArr = isArray(array),
-          isRight = dir < 0,
-          arrLength = isArr ? array.length : 0,
-          view = getView(0, arrLength, this.__views__),
-          start = view.start,
-          end = view.end,
-          length = end - start,
-          index = isRight ? end : (start - 1),
-          iteratees = this.__iteratees__,
-          iterLength = iteratees.length,
-          resIndex = 0,
-          takeCount = nativeMin(length, this.__takeCount__);
+        dir = this.__dir__,
+        isArr = isArray(array),
+        isRight = dir < 0,
+        arrLength = isArr ? array.length : 0,
+        view = getView(0, arrLength, this.__views__),
+        start = view.start,
+        end = view.end,
+        length = end - start,
+        index = isRight ? end : start - 1,
+        iteratees = this.__iteratees__,
+        iterLength = iteratees.length,
+        resIndex = 0,
+        takeCount = nativeMin(length, this.__takeCount__)
 
       if (!isArr || (!isRight && arrLength == length && takeCount == length)) {
-        return baseWrapperValue(array, this.__actions__);
+        return baseWrapperValue(array, this.__actions__)
       }
-      var result = [];
+      var result = []
 
-      outer:
-      while (length-- && resIndex < takeCount) {
-        index += dir;
+      outer: while (length-- && resIndex < takeCount) {
+        index += dir
 
         var iterIndex = -1,
-            value = array[index];
+          value = array[index]
 
         while (++iterIndex < iterLength) {
           var data = iteratees[iterIndex],
-              iteratee = data.iteratee,
-              type = data.type,
-              computed = iteratee(value);
+            iteratee = data.iteratee,
+            type = data.type,
+            computed = iteratee(value)
 
           if (type == LAZY_MAP_FLAG) {
-            value = computed;
+            value = computed
           } else if (!computed) {
             if (type == LAZY_FILTER_FLAG) {
-              continue outer;
+              continue outer
             } else {
-              break outer;
+              break outer
             }
           }
         }
-        result[resIndex++] = value;
+        result[resIndex++] = value
       }
-      return result;
+      return result
     }
 
     // Ensure `LazyWrapper` is an instance of `baseLodash`.
-    LazyWrapper.prototype = baseCreate(baseLodash.prototype);
-    LazyWrapper.prototype.constructor = LazyWrapper;
+    LazyWrapper.prototype = baseCreate(baseLodash.prototype)
+    LazyWrapper.prototype.constructor = LazyWrapper
 
     /*------------------------------------------------------------------------*/
 
@@ -1924,12 +2086,12 @@
      */
     function Hash(entries) {
       var index = -1,
-          length = entries == null ? 0 : entries.length;
+        length = entries == null ? 0 : entries.length
 
-      this.clear();
+      this.clear()
       while (++index < length) {
-        var entry = entries[index];
-        this.set(entry[0], entry[1]);
+        var entry = entries[index]
+        this.set(entry[0], entry[1])
       }
     }
 
@@ -1941,8 +2103,8 @@
      * @memberOf Hash
      */
     function hashClear() {
-      this.__data__ = nativeCreate ? nativeCreate(null) : {};
-      this.size = 0;
+      this.__data__ = nativeCreate ? nativeCreate(null) : {}
+      this.size = 0
     }
 
     /**
@@ -1956,9 +2118,9 @@
      * @returns {boolean} Returns `true` if the entry was removed, else `false`.
      */
     function hashDelete(key) {
-      var result = this.has(key) && delete this.__data__[key];
-      this.size -= result ? 1 : 0;
-      return result;
+      var result = this.has(key) && delete this.__data__[key]
+      this.size -= result ? 1 : 0
+      return result
     }
 
     /**
@@ -1971,12 +2133,12 @@
      * @returns {*} Returns the entry value.
      */
     function hashGet(key) {
-      var data = this.__data__;
+      var data = this.__data__
       if (nativeCreate) {
-        var result = data[key];
-        return result === HASH_UNDEFINED ? undefined : result;
+        var result = data[key]
+        return result === HASH_UNDEFINED ? undefined : result
       }
-      return hasOwnProperty.call(data, key) ? data[key] : undefined;
+      return hasOwnProperty.call(data, key) ? data[key] : undefined
     }
 
     /**
@@ -1989,8 +2151,8 @@
      * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
      */
     function hashHas(key) {
-      var data = this.__data__;
-      return nativeCreate ? (data[key] !== undefined) : hasOwnProperty.call(data, key);
+      var data = this.__data__
+      return nativeCreate ? data[key] !== undefined : hasOwnProperty.call(data, key)
     }
 
     /**
@@ -2004,18 +2166,18 @@
      * @returns {Object} Returns the hash instance.
      */
     function hashSet(key, value) {
-      var data = this.__data__;
-      this.size += this.has(key) ? 0 : 1;
-      data[key] = (nativeCreate && value === undefined) ? HASH_UNDEFINED : value;
-      return this;
+      var data = this.__data__
+      this.size += this.has(key) ? 0 : 1
+      data[key] = nativeCreate && value === undefined ? HASH_UNDEFINED : value
+      return this
     }
 
     // Add methods to `Hash`.
-    Hash.prototype.clear = hashClear;
-    Hash.prototype['delete'] = hashDelete;
-    Hash.prototype.get = hashGet;
-    Hash.prototype.has = hashHas;
-    Hash.prototype.set = hashSet;
+    Hash.prototype.clear = hashClear
+    Hash.prototype['delete'] = hashDelete
+    Hash.prototype.get = hashGet
+    Hash.prototype.has = hashHas
+    Hash.prototype.set = hashSet
 
     /*------------------------------------------------------------------------*/
 
@@ -2028,12 +2190,12 @@
      */
     function ListCache(entries) {
       var index = -1,
-          length = entries == null ? 0 : entries.length;
+        length = entries == null ? 0 : entries.length
 
-      this.clear();
+      this.clear()
       while (++index < length) {
-        var entry = entries[index];
-        this.set(entry[0], entry[1]);
+        var entry = entries[index]
+        this.set(entry[0], entry[1])
       }
     }
 
@@ -2045,8 +2207,8 @@
      * @memberOf ListCache
      */
     function listCacheClear() {
-      this.__data__ = [];
-      this.size = 0;
+      this.__data__ = []
+      this.size = 0
     }
 
     /**
@@ -2060,19 +2222,19 @@
      */
     function listCacheDelete(key) {
       var data = this.__data__,
-          index = assocIndexOf(data, key);
+        index = assocIndexOf(data, key)
 
       if (index < 0) {
-        return false;
+        return false
       }
-      var lastIndex = data.length - 1;
+      var lastIndex = data.length - 1
       if (index == lastIndex) {
-        data.pop();
+        data.pop()
       } else {
-        splice.call(data, index, 1);
+        splice.call(data, index, 1)
       }
-      --this.size;
-      return true;
+      --this.size
+      return true
     }
 
     /**
@@ -2086,9 +2248,9 @@
      */
     function listCacheGet(key) {
       var data = this.__data__,
-          index = assocIndexOf(data, key);
+        index = assocIndexOf(data, key)
 
-      return index < 0 ? undefined : data[index][1];
+      return index < 0 ? undefined : data[index][1]
     }
 
     /**
@@ -2101,7 +2263,7 @@
      * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
      */
     function listCacheHas(key) {
-      return assocIndexOf(this.__data__, key) > -1;
+      return assocIndexOf(this.__data__, key) > -1
     }
 
     /**
@@ -2116,23 +2278,23 @@
      */
     function listCacheSet(key, value) {
       var data = this.__data__,
-          index = assocIndexOf(data, key);
+        index = assocIndexOf(data, key)
 
       if (index < 0) {
-        ++this.size;
-        data.push([key, value]);
+        ++this.size
+        data.push([key, value])
       } else {
-        data[index][1] = value;
+        data[index][1] = value
       }
-      return this;
+      return this
     }
 
     // Add methods to `ListCache`.
-    ListCache.prototype.clear = listCacheClear;
-    ListCache.prototype['delete'] = listCacheDelete;
-    ListCache.prototype.get = listCacheGet;
-    ListCache.prototype.has = listCacheHas;
-    ListCache.prototype.set = listCacheSet;
+    ListCache.prototype.clear = listCacheClear
+    ListCache.prototype['delete'] = listCacheDelete
+    ListCache.prototype.get = listCacheGet
+    ListCache.prototype.has = listCacheHas
+    ListCache.prototype.set = listCacheSet
 
     /*------------------------------------------------------------------------*/
 
@@ -2145,12 +2307,12 @@
      */
     function MapCache(entries) {
       var index = -1,
-          length = entries == null ? 0 : entries.length;
+        length = entries == null ? 0 : entries.length
 
-      this.clear();
+      this.clear()
       while (++index < length) {
-        var entry = entries[index];
-        this.set(entry[0], entry[1]);
+        var entry = entries[index]
+        this.set(entry[0], entry[1])
       }
     }
 
@@ -2162,12 +2324,12 @@
      * @memberOf MapCache
      */
     function mapCacheClear() {
-      this.size = 0;
+      this.size = 0
       this.__data__ = {
-        'hash': new Hash,
-        'map': new (Map || ListCache),
-        'string': new Hash
-      };
+        hash: new Hash(),
+        map: new (Map || ListCache)(),
+        string: new Hash()
+      }
     }
 
     /**
@@ -2180,9 +2342,9 @@
      * @returns {boolean} Returns `true` if the entry was removed, else `false`.
      */
     function mapCacheDelete(key) {
-      var result = getMapData(this, key)['delete'](key);
-      this.size -= result ? 1 : 0;
-      return result;
+      var result = getMapData(this, key)['delete'](key)
+      this.size -= result ? 1 : 0
+      return result
     }
 
     /**
@@ -2195,7 +2357,7 @@
      * @returns {*} Returns the entry value.
      */
     function mapCacheGet(key) {
-      return getMapData(this, key).get(key);
+      return getMapData(this, key).get(key)
     }
 
     /**
@@ -2208,7 +2370,7 @@
      * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
      */
     function mapCacheHas(key) {
-      return getMapData(this, key).has(key);
+      return getMapData(this, key).has(key)
     }
 
     /**
@@ -2223,19 +2385,19 @@
      */
     function mapCacheSet(key, value) {
       var data = getMapData(this, key),
-          size = data.size;
+        size = data.size
 
-      data.set(key, value);
-      this.size += data.size == size ? 0 : 1;
-      return this;
+      data.set(key, value)
+      this.size += data.size == size ? 0 : 1
+      return this
     }
 
     // Add methods to `MapCache`.
-    MapCache.prototype.clear = mapCacheClear;
-    MapCache.prototype['delete'] = mapCacheDelete;
-    MapCache.prototype.get = mapCacheGet;
-    MapCache.prototype.has = mapCacheHas;
-    MapCache.prototype.set = mapCacheSet;
+    MapCache.prototype.clear = mapCacheClear
+    MapCache.prototype['delete'] = mapCacheDelete
+    MapCache.prototype.get = mapCacheGet
+    MapCache.prototype.has = mapCacheHas
+    MapCache.prototype.set = mapCacheSet
 
     /*------------------------------------------------------------------------*/
 
@@ -2249,11 +2411,11 @@
      */
     function SetCache(values) {
       var index = -1,
-          length = values == null ? 0 : values.length;
+        length = values == null ? 0 : values.length
 
-      this.__data__ = new MapCache;
+      this.__data__ = new MapCache()
       while (++index < length) {
-        this.add(values[index]);
+        this.add(values[index])
       }
     }
 
@@ -2268,8 +2430,8 @@
      * @returns {Object} Returns the cache instance.
      */
     function setCacheAdd(value) {
-      this.__data__.set(value, HASH_UNDEFINED);
-      return this;
+      this.__data__.set(value, HASH_UNDEFINED)
+      return this
     }
 
     /**
@@ -2282,12 +2444,12 @@
      * @returns {number} Returns `true` if `value` is found, else `false`.
      */
     function setCacheHas(value) {
-      return this.__data__.has(value);
+      return this.__data__.has(value)
     }
 
     // Add methods to `SetCache`.
-    SetCache.prototype.add = SetCache.prototype.push = setCacheAdd;
-    SetCache.prototype.has = setCacheHas;
+    SetCache.prototype.add = SetCache.prototype.push = setCacheAdd
+    SetCache.prototype.has = setCacheHas
 
     /*------------------------------------------------------------------------*/
 
@@ -2299,8 +2461,8 @@
      * @param {Array} [entries] The key-value pairs to cache.
      */
     function Stack(entries) {
-      var data = this.__data__ = new ListCache(entries);
-      this.size = data.size;
+      var data = (this.__data__ = new ListCache(entries))
+      this.size = data.size
     }
 
     /**
@@ -2311,8 +2473,8 @@
      * @memberOf Stack
      */
     function stackClear() {
-      this.__data__ = new ListCache;
-      this.size = 0;
+      this.__data__ = new ListCache()
+      this.size = 0
     }
 
     /**
@@ -2326,10 +2488,10 @@
      */
     function stackDelete(key) {
       var data = this.__data__,
-          result = data['delete'](key);
+        result = data['delete'](key)
 
-      this.size = data.size;
-      return result;
+      this.size = data.size
+      return result
     }
 
     /**
@@ -2342,7 +2504,7 @@
      * @returns {*} Returns the entry value.
      */
     function stackGet(key) {
-      return this.__data__.get(key);
+      return this.__data__.get(key)
     }
 
     /**
@@ -2355,7 +2517,7 @@
      * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
      */
     function stackHas(key) {
-      return this.__data__.has(key);
+      return this.__data__.has(key)
     }
 
     /**
@@ -2369,27 +2531,27 @@
      * @returns {Object} Returns the stack cache instance.
      */
     function stackSet(key, value) {
-      var data = this.__data__;
+      var data = this.__data__
       if (data instanceof ListCache) {
-        var pairs = data.__data__;
-        if (!Map || (pairs.length < LARGE_ARRAY_SIZE - 1)) {
-          pairs.push([key, value]);
-          this.size = ++data.size;
-          return this;
+        var pairs = data.__data__
+        if (!Map || pairs.length < LARGE_ARRAY_SIZE - 1) {
+          pairs.push([key, value])
+          this.size = ++data.size
+          return this
         }
-        data = this.__data__ = new MapCache(pairs);
+        data = this.__data__ = new MapCache(pairs)
       }
-      data.set(key, value);
-      this.size = data.size;
-      return this;
+      data.set(key, value)
+      this.size = data.size
+      return this
     }
 
     // Add methods to `Stack`.
-    Stack.prototype.clear = stackClear;
-    Stack.prototype['delete'] = stackDelete;
-    Stack.prototype.get = stackGet;
-    Stack.prototype.has = stackHas;
-    Stack.prototype.set = stackSet;
+    Stack.prototype.clear = stackClear
+    Stack.prototype['delete'] = stackDelete
+    Stack.prototype.get = stackGet
+    Stack.prototype.has = stackHas
+    Stack.prototype.set = stackSet
 
     /*------------------------------------------------------------------------*/
 
@@ -2403,29 +2565,32 @@
      */
     function arrayLikeKeys(value, inherited) {
       var isArr = isArray(value),
-          isArg = !isArr && isArguments(value),
-          isBuff = !isArr && !isArg && isBuffer(value),
-          isType = !isArr && !isArg && !isBuff && isTypedArray(value),
-          skipIndexes = isArr || isArg || isBuff || isType,
-          result = skipIndexes ? baseTimes(value.length, String) : [],
-          length = result.length;
+        isArg = !isArr && isArguments(value),
+        isBuff = !isArr && !isArg && isBuffer(value),
+        isType = !isArr && !isArg && !isBuff && isTypedArray(value),
+        skipIndexes = isArr || isArg || isBuff || isType,
+        result = skipIndexes ? baseTimes(value.length, String) : [],
+        length = result.length
 
       for (var key in value) {
-        if ((inherited || hasOwnProperty.call(value, key)) &&
-            !(skipIndexes && (
-               // Safari 9 has enumerable `arguments.length` in strict mode.
-               key == 'length' ||
-               // Node.js 0.10 has enumerable non-index properties on buffers.
-               (isBuff && (key == 'offset' || key == 'parent')) ||
-               // PhantomJS 2 has enumerable non-index properties on typed arrays.
-               (isType && (key == 'buffer' || key == 'byteLength' || key == 'byteOffset')) ||
-               // Skip index properties.
-               isIndex(key, length)
-            ))) {
-          result.push(key);
+        if (
+          (inherited || hasOwnProperty.call(value, key)) &&
+          !(
+            skipIndexes &&
+            // Safari 9 has enumerable `arguments.length` in strict mode.
+            (key == 'length' ||
+              // Node.js 0.10 has enumerable non-index properties on buffers.
+              (isBuff && (key == 'offset' || key == 'parent')) ||
+              // PhantomJS 2 has enumerable non-index properties on typed arrays.
+              (isType && (key == 'buffer' || key == 'byteLength' || key == 'byteOffset')) ||
+              // Skip index properties.
+              isIndex(key, length))
+          )
+        ) {
+          result.push(key)
         }
       }
-      return result;
+      return result
     }
 
     /**
@@ -2436,8 +2601,8 @@
      * @returns {*} Returns the random element.
      */
     function arraySample(array) {
-      var length = array.length;
-      return length ? array[baseRandom(0, length - 1)] : undefined;
+      var length = array.length
+      return length ? array[baseRandom(0, length - 1)] : undefined
     }
 
     /**
@@ -2449,7 +2614,7 @@
      * @returns {Array} Returns the random elements.
      */
     function arraySampleSize(array, n) {
-      return shuffleSelf(copyArray(array), baseClamp(n, 0, array.length));
+      return shuffleSelf(copyArray(array), baseClamp(n, 0, array.length))
     }
 
     /**
@@ -2460,7 +2625,7 @@
      * @returns {Array} Returns the new shuffled array.
      */
     function arrayShuffle(array) {
-      return shuffleSelf(copyArray(array));
+      return shuffleSelf(copyArray(array))
     }
 
     /**
@@ -2473,9 +2638,8 @@
      * @param {*} value The value to assign.
      */
     function assignMergeValue(object, key, value) {
-      if ((value !== undefined && !eq(object[key], value)) ||
-          (value === undefined && !(key in object))) {
-        baseAssignValue(object, key, value);
+      if ((value !== undefined && !eq(object[key], value)) || (value === undefined && !(key in object))) {
+        baseAssignValue(object, key, value)
       }
     }
 
@@ -2490,10 +2654,9 @@
      * @param {*} value The value to assign.
      */
     function assignValue(object, key, value) {
-      var objValue = object[key];
-      if (!(hasOwnProperty.call(object, key) && eq(objValue, value)) ||
-          (value === undefined && !(key in object))) {
-        baseAssignValue(object, key, value);
+      var objValue = object[key]
+      if (!(hasOwnProperty.call(object, key) && eq(objValue, value)) || (value === undefined && !(key in object))) {
+        baseAssignValue(object, key, value)
       }
     }
 
@@ -2506,13 +2669,13 @@
      * @returns {number} Returns the index of the matched value, else `-1`.
      */
     function assocIndexOf(array, key) {
-      var length = array.length;
+      var length = array.length
       while (length--) {
         if (eq(array[length][0], key)) {
-          return length;
+          return length
         }
       }
-      return -1;
+      return -1
     }
 
     /**
@@ -2528,9 +2691,9 @@
      */
     function baseAggregator(collection, setter, iteratee, accumulator) {
       baseEach(collection, function(value, key, collection) {
-        setter(accumulator, value, iteratee(value), collection);
-      });
-      return accumulator;
+        setter(accumulator, value, iteratee(value), collection)
+      })
+      return accumulator
     }
 
     /**
@@ -2543,7 +2706,7 @@
      * @returns {Object} Returns `object`.
      */
     function baseAssign(object, source) {
-      return object && copyObject(source, keys(source), object);
+      return object && copyObject(source, keys(source), object)
     }
 
     /**
@@ -2556,7 +2719,7 @@
      * @returns {Object} Returns `object`.
      */
     function baseAssignIn(object, source) {
-      return object && copyObject(source, keysIn(source), object);
+      return object && copyObject(source, keysIn(source), object)
     }
 
     /**
@@ -2571,13 +2734,13 @@
     function baseAssignValue(object, key, value) {
       if (key == '__proto__' && defineProperty) {
         defineProperty(object, key, {
-          'configurable': true,
-          'enumerable': true,
-          'value': value,
-          'writable': true
-        });
+          configurable: true,
+          enumerable: true,
+          value: value,
+          writable: true
+        })
       } else {
-        object[key] = value;
+        object[key] = value
       }
     }
 
@@ -2591,14 +2754,14 @@
      */
     function baseAt(object, paths) {
       var index = -1,
-          length = paths.length,
-          result = Array(length),
-          skip = object == null;
+        length = paths.length,
+        result = Array(length),
+        skip = object == null
 
       while (++index < length) {
-        result[index] = skip ? undefined : get(object, paths[index]);
+        result[index] = skip ? undefined : get(object, paths[index])
       }
-      return result;
+      return result
     }
 
     /**
@@ -2613,13 +2776,13 @@
     function baseClamp(number, lower, upper) {
       if (number === number) {
         if (upper !== undefined) {
-          number = number <= upper ? number : upper;
+          number = number <= upper ? number : upper
         }
         if (lower !== undefined) {
-          number = number >= lower ? number : lower;
+          number = number >= lower ? number : lower
         }
       }
-      return number;
+      return number
     }
 
     /**
@@ -2640,68 +2803,66 @@
      */
     function baseClone(value, bitmask, customizer, key, object, stack) {
       var result,
-          isDeep = bitmask & CLONE_DEEP_FLAG,
-          isFlat = bitmask & CLONE_FLAT_FLAG,
-          isFull = bitmask & CLONE_SYMBOLS_FLAG;
+        isDeep = bitmask & CLONE_DEEP_FLAG,
+        isFlat = bitmask & CLONE_FLAT_FLAG,
+        isFull = bitmask & CLONE_SYMBOLS_FLAG
 
       if (customizer) {
-        result = object ? customizer(value, key, object, stack) : customizer(value);
+        result = object ? customizer(value, key, object, stack) : customizer(value)
       }
       if (result !== undefined) {
-        return result;
+        return result
       }
       if (!isObject(value)) {
-        return value;
+        return value
       }
-      var isArr = isArray(value);
+      var isArr = isArray(value)
       if (isArr) {
-        result = initCloneArray(value);
+        result = initCloneArray(value)
         if (!isDeep) {
-          return copyArray(value, result);
+          return copyArray(value, result)
         }
       } else {
         var tag = getTag(value),
-            isFunc = tag == funcTag || tag == genTag;
+          isFunc = tag == funcTag || tag == genTag
 
         if (isBuffer(value)) {
-          return cloneBuffer(value, isDeep);
+          return cloneBuffer(value, isDeep)
         }
         if (tag == objectTag || tag == argsTag || (isFunc && !object)) {
-          result = (isFlat || isFunc) ? {} : initCloneObject(value);
+          result = isFlat || isFunc ? {} : initCloneObject(value)
           if (!isDeep) {
             return isFlat
               ? copySymbolsIn(value, baseAssignIn(result, value))
-              : copySymbols(value, baseAssign(result, value));
+              : copySymbols(value, baseAssign(result, value))
           }
         } else {
           if (!cloneableTags[tag]) {
-            return object ? value : {};
+            return object ? value : {}
           }
-          result = initCloneByTag(value, tag, baseClone, isDeep);
+          result = initCloneByTag(value, tag, baseClone, isDeep)
         }
       }
       // Check for circular references and return its corresponding clone.
-      stack || (stack = new Stack);
-      var stacked = stack.get(value);
+      stack || (stack = new Stack())
+      var stacked = stack.get(value)
       if (stacked) {
-        return stacked;
+        return stacked
       }
-      stack.set(value, result);
+      stack.set(value, result)
 
-      var keysFunc = isFull
-        ? (isFlat ? getAllKeysIn : getAllKeys)
-        : (isFlat ? keysIn : keys);
+      var keysFunc = isFull ? (isFlat ? getAllKeysIn : getAllKeys) : isFlat ? keysIn : keys
 
-      var props = isArr ? undefined : keysFunc(value);
+      var props = isArr ? undefined : keysFunc(value)
       arrayEach(props || value, function(subValue, key) {
         if (props) {
-          key = subValue;
-          subValue = value[key];
+          key = subValue
+          subValue = value[key]
         }
         // Recursively populate clone (susceptible to call stack limits).
-        assignValue(result, key, baseClone(subValue, bitmask, customizer, key, value, stack));
-      });
-      return result;
+        assignValue(result, key, baseClone(subValue, bitmask, customizer, key, value, stack))
+      })
+      return result
     }
 
     /**
@@ -2712,10 +2873,10 @@
      * @returns {Function} Returns the new spec function.
      */
     function baseConforms(source) {
-      var props = keys(source);
+      var props = keys(source)
       return function(object) {
-        return baseConformsTo(object, source, props);
-      };
+        return baseConformsTo(object, source, props)
+      }
     }
 
     /**
@@ -2727,21 +2888,21 @@
      * @returns {boolean} Returns `true` if `object` conforms, else `false`.
      */
     function baseConformsTo(object, source, props) {
-      var length = props.length;
+      var length = props.length
       if (object == null) {
-        return !length;
+        return !length
       }
-      object = Object(object);
+      object = Object(object)
       while (length--) {
         var key = props[length],
-            predicate = source[key],
-            value = object[key];
+          predicate = source[key],
+          value = object[key]
 
         if ((value === undefined && !(key in object)) || !predicate(value)) {
-          return false;
+          return false
         }
       }
-      return true;
+      return true
     }
 
     /**
@@ -2756,9 +2917,11 @@
      */
     function baseDelay(func, wait, args) {
       if (typeof func != 'function') {
-        throw new TypeError(FUNC_ERROR_TEXT);
+        throw new TypeError(FUNC_ERROR_TEXT)
       }
-      return setTimeout(function() { func.apply(undefined, args); }, wait);
+      return setTimeout(function() {
+        func.apply(undefined, args)
+      }, wait)
     }
 
     /**
@@ -2774,47 +2937,44 @@
      */
     function baseDifference(array, values, iteratee, comparator) {
       var index = -1,
-          includes = arrayIncludes,
-          isCommon = true,
-          length = array.length,
-          result = [],
-          valuesLength = values.length;
+        includes = arrayIncludes,
+        isCommon = true,
+        length = array.length,
+        result = [],
+        valuesLength = values.length
 
       if (!length) {
-        return result;
+        return result
       }
       if (iteratee) {
-        values = arrayMap(values, baseUnary(iteratee));
+        values = arrayMap(values, baseUnary(iteratee))
       }
       if (comparator) {
-        includes = arrayIncludesWith;
-        isCommon = false;
+        includes = arrayIncludesWith
+        isCommon = false
+      } else if (values.length >= LARGE_ARRAY_SIZE) {
+        includes = cacheHas
+        isCommon = false
+        values = new SetCache(values)
       }
-      else if (values.length >= LARGE_ARRAY_SIZE) {
-        includes = cacheHas;
-        isCommon = false;
-        values = new SetCache(values);
-      }
-      outer:
-      while (++index < length) {
+      outer: while (++index < length) {
         var value = array[index],
-            computed = iteratee == null ? value : iteratee(value);
+          computed = iteratee == null ? value : iteratee(value)
 
-        value = (comparator || value !== 0) ? value : 0;
+        value = comparator || value !== 0 ? value : 0
         if (isCommon && computed === computed) {
-          var valuesIndex = valuesLength;
+          var valuesIndex = valuesLength
           while (valuesIndex--) {
             if (values[valuesIndex] === computed) {
-              continue outer;
+              continue outer
             }
           }
-          result.push(value);
-        }
-        else if (!includes(values, computed, comparator)) {
-          result.push(value);
+          result.push(value)
+        } else if (!includes(values, computed, comparator)) {
+          result.push(value)
         }
       }
-      return result;
+      return result
     }
 
     /**
@@ -2825,7 +2985,7 @@
      * @param {Function} iteratee The function invoked per iteration.
      * @returns {Array|Object} Returns `collection`.
      */
-    var baseEach = createBaseEach(baseForOwn);
+    var baseEach = createBaseEach(baseForOwn)
 
     /**
      * The base implementation of `_.forEachRight` without support for iteratee shorthands.
@@ -2835,7 +2995,7 @@
      * @param {Function} iteratee The function invoked per iteration.
      * @returns {Array|Object} Returns `collection`.
      */
-    var baseEachRight = createBaseEach(baseForOwnRight, true);
+    var baseEachRight = createBaseEach(baseForOwnRight, true)
 
     /**
      * The base implementation of `_.every` without support for iteratee shorthands.
@@ -2847,12 +3007,12 @@
      *  else `false`
      */
     function baseEvery(collection, predicate) {
-      var result = true;
+      var result = true
       baseEach(collection, function(value, index, collection) {
-        result = !!predicate(value, index, collection);
-        return result;
-      });
-      return result;
+        result = !!predicate(value, index, collection)
+        return result
+      })
+      return result
     }
 
     /**
@@ -2867,21 +3027,21 @@
      */
     function baseExtremum(array, iteratee, comparator) {
       var index = -1,
-          length = array.length;
+        length = array.length
 
       while (++index < length) {
         var value = array[index],
-            current = iteratee(value);
+          current = iteratee(value)
 
-        if (current != null && (computed === undefined
-              ? (current === current && !isSymbol(current))
-              : comparator(current, computed)
-            )) {
+        if (
+          current != null &&
+          (computed === undefined ? current === current && !isSymbol(current) : comparator(current, computed))
+        ) {
           var computed = current,
-              result = value;
+            result = value
         }
       }
-      return result;
+      return result
     }
 
     /**
@@ -2895,21 +3055,21 @@
      * @returns {Array} Returns `array`.
      */
     function baseFill(array, value, start, end) {
-      var length = array.length;
+      var length = array.length
 
-      start = toInteger(start);
+      start = toInteger(start)
       if (start < 0) {
-        start = -start > length ? 0 : (length + start);
+        start = -start > length ? 0 : length + start
       }
-      end = (end === undefined || end > length) ? length : toInteger(end);
+      end = end === undefined || end > length ? length : toInteger(end)
       if (end < 0) {
-        end += length;
+        end += length
       }
-      end = start > end ? 0 : toLength(end);
+      end = start > end ? 0 : toLength(end)
       while (start < end) {
-        array[start++] = value;
+        array[start++] = value
       }
-      return array;
+      return array
     }
 
     /**
@@ -2921,13 +3081,13 @@
      * @returns {Array} Returns the new filtered array.
      */
     function baseFilter(collection, predicate) {
-      var result = [];
+      var result = []
       baseEach(collection, function(value, index, collection) {
         if (predicate(value, index, collection)) {
-          result.push(value);
+          result.push(value)
         }
-      });
-      return result;
+      })
+      return result
     }
 
     /**
@@ -2943,25 +3103,25 @@
      */
     function baseFlatten(array, depth, predicate, isStrict, result) {
       var index = -1,
-          length = array.length;
+        length = array.length
 
-      predicate || (predicate = isFlattenable);
-      result || (result = []);
+      predicate || (predicate = isFlattenable)
+      result || (result = [])
 
       while (++index < length) {
-        var value = array[index];
+        var value = array[index]
         if (depth > 0 && predicate(value)) {
           if (depth > 1) {
             // Recursively flatten arrays (susceptible to call stack limits).
-            baseFlatten(value, depth - 1, predicate, isStrict, result);
+            baseFlatten(value, depth - 1, predicate, isStrict, result)
           } else {
-            arrayPush(result, value);
+            arrayPush(result, value)
           }
         } else if (!isStrict) {
-          result[result.length] = value;
+          result[result.length] = value
         }
       }
-      return result;
+      return result
     }
 
     /**
@@ -2975,7 +3135,7 @@
      * @param {Function} keysFunc The function to get the keys of `object`.
      * @returns {Object} Returns `object`.
      */
-    var baseFor = createBaseFor();
+    var baseFor = createBaseFor()
 
     /**
      * This function is like `baseFor` except that it iterates over properties
@@ -2987,7 +3147,7 @@
      * @param {Function} keysFunc The function to get the keys of `object`.
      * @returns {Object} Returns `object`.
      */
-    var baseForRight = createBaseFor(true);
+    var baseForRight = createBaseFor(true)
 
     /**
      * The base implementation of `_.forOwn` without support for iteratee shorthands.
@@ -2998,7 +3158,7 @@
      * @returns {Object} Returns `object`.
      */
     function baseForOwn(object, iteratee) {
-      return object && baseFor(object, iteratee, keys);
+      return object && baseFor(object, iteratee, keys)
     }
 
     /**
@@ -3010,7 +3170,7 @@
      * @returns {Object} Returns `object`.
      */
     function baseForOwnRight(object, iteratee) {
-      return object && baseForRight(object, iteratee, keys);
+      return object && baseForRight(object, iteratee, keys)
     }
 
     /**
@@ -3024,8 +3184,8 @@
      */
     function baseFunctions(object, props) {
       return arrayFilter(props, function(key) {
-        return isFunction(object[key]);
-      });
+        return isFunction(object[key])
+      })
     }
 
     /**
@@ -3037,15 +3197,15 @@
      * @returns {*} Returns the resolved value.
      */
     function baseGet(object, path) {
-      path = castPath(path, object);
+      path = castPath(path, object)
 
       var index = 0,
-          length = path.length;
+        length = path.length
 
       while (object != null && index < length) {
-        object = object[toKey(path[index++])];
+        object = object[toKey(path[index++])]
       }
-      return (index && index == length) ? object : undefined;
+      return index && index == length ? object : undefined
     }
 
     /**
@@ -3060,8 +3220,8 @@
      * @returns {Array} Returns the array of property names and symbols.
      */
     function baseGetAllKeys(object, keysFunc, symbolsFunc) {
-      var result = keysFunc(object);
-      return isArray(object) ? result : arrayPush(result, symbolsFunc(object));
+      var result = keysFunc(object)
+      return isArray(object) ? result : arrayPush(result, symbolsFunc(object))
     }
 
     /**
@@ -3073,11 +3233,9 @@
      */
     function baseGetTag(value) {
       if (value == null) {
-        return value === undefined ? undefinedTag : nullTag;
+        return value === undefined ? undefinedTag : nullTag
       }
-      return (symToStringTag && symToStringTag in Object(value))
-        ? getRawTag(value)
-        : objectToString(value);
+      return symToStringTag && symToStringTag in Object(value) ? getRawTag(value) : objectToString(value)
     }
 
     /**
@@ -3090,7 +3248,7 @@
      *  else `false`.
      */
     function baseGt(value, other) {
-      return value > other;
+      return value > other
     }
 
     /**
@@ -3102,7 +3260,7 @@
      * @returns {boolean} Returns `true` if `key` exists, else `false`.
      */
     function baseHas(object, key) {
-      return object != null && hasOwnProperty.call(object, key);
+      return object != null && hasOwnProperty.call(object, key)
     }
 
     /**
@@ -3114,7 +3272,7 @@
      * @returns {boolean} Returns `true` if `key` exists, else `false`.
      */
     function baseHasIn(object, key) {
-      return object != null && key in Object(object);
+      return object != null && key in Object(object)
     }
 
     /**
@@ -3127,7 +3285,7 @@
      * @returns {boolean} Returns `true` if `number` is in the range, else `false`.
      */
     function baseInRange(number, start, end) {
-      return number >= nativeMin(start, end) && number < nativeMax(start, end);
+      return number >= nativeMin(start, end) && number < nativeMax(start, end)
     }
 
     /**
@@ -3142,55 +3300,49 @@
      */
     function baseIntersection(arrays, iteratee, comparator) {
       var includes = comparator ? arrayIncludesWith : arrayIncludes,
-          length = arrays[0].length,
-          othLength = arrays.length,
-          othIndex = othLength,
-          caches = Array(othLength),
-          maxLength = Infinity,
-          result = [];
+        length = arrays[0].length,
+        othLength = arrays.length,
+        othIndex = othLength,
+        caches = Array(othLength),
+        maxLength = Infinity,
+        result = []
 
       while (othIndex--) {
-        var array = arrays[othIndex];
+        var array = arrays[othIndex]
         if (othIndex && iteratee) {
-          array = arrayMap(array, baseUnary(iteratee));
+          array = arrayMap(array, baseUnary(iteratee))
         }
-        maxLength = nativeMin(array.length, maxLength);
-        caches[othIndex] = !comparator && (iteratee || (length >= 120 && array.length >= 120))
-          ? new SetCache(othIndex && array)
-          : undefined;
+        maxLength = nativeMin(array.length, maxLength)
+        caches[othIndex] =
+          !comparator && (iteratee || (length >= 120 && array.length >= 120))
+            ? new SetCache(othIndex && array)
+            : undefined
       }
-      array = arrays[0];
+      array = arrays[0]
 
       var index = -1,
-          seen = caches[0];
+        seen = caches[0]
 
-      outer:
-      while (++index < length && result.length < maxLength) {
+      outer: while (++index < length && result.length < maxLength) {
         var value = array[index],
-            computed = iteratee ? iteratee(value) : value;
+          computed = iteratee ? iteratee(value) : value
 
-        value = (comparator || value !== 0) ? value : 0;
-        if (!(seen
-              ? cacheHas(seen, computed)
-              : includes(result, computed, comparator)
-            )) {
-          othIndex = othLength;
+        value = comparator || value !== 0 ? value : 0
+        if (!(seen ? cacheHas(seen, computed) : includes(result, computed, comparator))) {
+          othIndex = othLength
           while (--othIndex) {
-            var cache = caches[othIndex];
-            if (!(cache
-                  ? cacheHas(cache, computed)
-                  : includes(arrays[othIndex], computed, comparator))
-                ) {
-              continue outer;
+            var cache = caches[othIndex]
+            if (!(cache ? cacheHas(cache, computed) : includes(arrays[othIndex], computed, comparator))) {
+              continue outer
             }
           }
           if (seen) {
-            seen.push(computed);
+            seen.push(computed)
           }
-          result.push(value);
+          result.push(value)
         }
       }
-      return result;
+      return result
     }
 
     /**
@@ -3206,9 +3358,9 @@
      */
     function baseInverter(object, setter, iteratee, accumulator) {
       baseForOwn(object, function(value, key, object) {
-        setter(accumulator, iteratee(value), key, object);
-      });
-      return accumulator;
+        setter(accumulator, iteratee(value), key, object)
+      })
+      return accumulator
     }
 
     /**
@@ -3222,10 +3374,10 @@
      * @returns {*} Returns the result of the invoked method.
      */
     function baseInvoke(object, path, args) {
-      path = castPath(path, object);
-      object = parent(object, path);
-      var func = object == null ? object : object[toKey(last(path))];
-      return func == null ? undefined : apply(func, object, args);
+      path = castPath(path, object)
+      object = parent(object, path)
+      var func = object == null ? object : object[toKey(last(path))]
+      return func == null ? undefined : apply(func, object, args)
     }
 
     /**
@@ -3236,7 +3388,7 @@
      * @returns {boolean} Returns `true` if `value` is an `arguments` object,
      */
     function baseIsArguments(value) {
-      return isObjectLike(value) && baseGetTag(value) == argsTag;
+      return isObjectLike(value) && baseGetTag(value) == argsTag
     }
 
     /**
@@ -3247,7 +3399,7 @@
      * @returns {boolean} Returns `true` if `value` is an array buffer, else `false`.
      */
     function baseIsArrayBuffer(value) {
-      return isObjectLike(value) && baseGetTag(value) == arrayBufferTag;
+      return isObjectLike(value) && baseGetTag(value) == arrayBufferTag
     }
 
     /**
@@ -3258,7 +3410,7 @@
      * @returns {boolean} Returns `true` if `value` is a date object, else `false`.
      */
     function baseIsDate(value) {
-      return isObjectLike(value) && baseGetTag(value) == dateTag;
+      return isObjectLike(value) && baseGetTag(value) == dateTag
     }
 
     /**
@@ -3277,12 +3429,12 @@
      */
     function baseIsEqual(value, other, bitmask, customizer, stack) {
       if (value === other) {
-        return true;
+        return true
       }
       if (value == null || other == null || (!isObjectLike(value) && !isObjectLike(other))) {
-        return value !== value && other !== other;
+        return value !== value && other !== other
       }
-      return baseIsEqualDeep(value, other, bitmask, customizer, baseIsEqual, stack);
+      return baseIsEqualDeep(value, other, bitmask, customizer, baseIsEqual, stack)
     }
 
     /**
@@ -3301,47 +3453,47 @@
      */
     function baseIsEqualDeep(object, other, bitmask, customizer, equalFunc, stack) {
       var objIsArr = isArray(object),
-          othIsArr = isArray(other),
-          objTag = objIsArr ? arrayTag : getTag(object),
-          othTag = othIsArr ? arrayTag : getTag(other);
+        othIsArr = isArray(other),
+        objTag = objIsArr ? arrayTag : getTag(object),
+        othTag = othIsArr ? arrayTag : getTag(other)
 
-      objTag = objTag == argsTag ? objectTag : objTag;
-      othTag = othTag == argsTag ? objectTag : othTag;
+      objTag = objTag == argsTag ? objectTag : objTag
+      othTag = othTag == argsTag ? objectTag : othTag
 
       var objIsObj = objTag == objectTag,
-          othIsObj = othTag == objectTag,
-          isSameTag = objTag == othTag;
+        othIsObj = othTag == objectTag,
+        isSameTag = objTag == othTag
 
       if (isSameTag && isBuffer(object)) {
         if (!isBuffer(other)) {
-          return false;
+          return false
         }
-        objIsArr = true;
-        objIsObj = false;
+        objIsArr = true
+        objIsObj = false
       }
       if (isSameTag && !objIsObj) {
-        stack || (stack = new Stack);
-        return (objIsArr || isTypedArray(object))
+        stack || (stack = new Stack())
+        return objIsArr || isTypedArray(object)
           ? equalArrays(object, other, bitmask, customizer, equalFunc, stack)
-          : equalByTag(object, other, objTag, bitmask, customizer, equalFunc, stack);
+          : equalByTag(object, other, objTag, bitmask, customizer, equalFunc, stack)
       }
       if (!(bitmask & COMPARE_PARTIAL_FLAG)) {
         var objIsWrapped = objIsObj && hasOwnProperty.call(object, '__wrapped__'),
-            othIsWrapped = othIsObj && hasOwnProperty.call(other, '__wrapped__');
+          othIsWrapped = othIsObj && hasOwnProperty.call(other, '__wrapped__')
 
         if (objIsWrapped || othIsWrapped) {
           var objUnwrapped = objIsWrapped ? object.value() : object,
-              othUnwrapped = othIsWrapped ? other.value() : other;
+            othUnwrapped = othIsWrapped ? other.value() : other
 
-          stack || (stack = new Stack);
-          return equalFunc(objUnwrapped, othUnwrapped, bitmask, customizer, stack);
+          stack || (stack = new Stack())
+          return equalFunc(objUnwrapped, othUnwrapped, bitmask, customizer, stack)
         }
       }
       if (!isSameTag) {
-        return false;
+        return false
       }
-      stack || (stack = new Stack);
-      return equalObjects(object, other, bitmask, customizer, equalFunc, stack);
+      stack || (stack = new Stack())
+      return equalObjects(object, other, bitmask, customizer, equalFunc, stack)
     }
 
     /**
@@ -3352,7 +3504,7 @@
      * @returns {boolean} Returns `true` if `value` is a map, else `false`.
      */
     function baseIsMap(value) {
-      return isObjectLike(value) && getTag(value) == mapTag;
+      return isObjectLike(value) && getTag(value) == mapTag
     }
 
     /**
@@ -3367,46 +3519,44 @@
      */
     function baseIsMatch(object, source, matchData, customizer) {
       var index = matchData.length,
-          length = index,
-          noCustomizer = !customizer;
+        length = index,
+        noCustomizer = !customizer
 
       if (object == null) {
-        return !length;
+        return !length
       }
-      object = Object(object);
+      object = Object(object)
       while (index--) {
-        var data = matchData[index];
-        if ((noCustomizer && data[2])
-              ? data[1] !== object[data[0]]
-              : !(data[0] in object)
-            ) {
-          return false;
+        var data = matchData[index]
+        if (noCustomizer && data[2] ? data[1] !== object[data[0]] : !(data[0] in object)) {
+          return false
         }
       }
       while (++index < length) {
-        data = matchData[index];
+        data = matchData[index]
         var key = data[0],
-            objValue = object[key],
-            srcValue = data[1];
+          objValue = object[key],
+          srcValue = data[1]
 
         if (noCustomizer && data[2]) {
           if (objValue === undefined && !(key in object)) {
-            return false;
+            return false
           }
         } else {
-          var stack = new Stack;
+          var stack = new Stack()
           if (customizer) {
-            var result = customizer(objValue, srcValue, key, object, source, stack);
+            var result = customizer(objValue, srcValue, key, object, source, stack)
           }
-          if (!(result === undefined
-                ? baseIsEqual(srcValue, objValue, COMPARE_PARTIAL_FLAG | COMPARE_UNORDERED_FLAG, customizer, stack)
-                : result
-              )) {
-            return false;
+          if (
+            !(result === undefined
+              ? baseIsEqual(srcValue, objValue, COMPARE_PARTIAL_FLAG | COMPARE_UNORDERED_FLAG, customizer, stack)
+              : result)
+          ) {
+            return false
           }
         }
       }
-      return true;
+      return true
     }
 
     /**
@@ -3419,10 +3569,10 @@
      */
     function baseIsNative(value) {
       if (!isObject(value) || isMasked(value)) {
-        return false;
+        return false
       }
-      var pattern = isFunction(value) ? reIsNative : reIsHostCtor;
-      return pattern.test(toSource(value));
+      var pattern = isFunction(value) ? reIsNative : reIsHostCtor
+      return pattern.test(toSource(value))
     }
 
     /**
@@ -3433,7 +3583,7 @@
      * @returns {boolean} Returns `true` if `value` is a regexp, else `false`.
      */
     function baseIsRegExp(value) {
-      return isObjectLike(value) && baseGetTag(value) == regexpTag;
+      return isObjectLike(value) && baseGetTag(value) == regexpTag
     }
 
     /**
@@ -3444,7 +3594,7 @@
      * @returns {boolean} Returns `true` if `value` is a set, else `false`.
      */
     function baseIsSet(value) {
-      return isObjectLike(value) && getTag(value) == setTag;
+      return isObjectLike(value) && getTag(value) == setTag
     }
 
     /**
@@ -3455,8 +3605,7 @@
      * @returns {boolean} Returns `true` if `value` is a typed array, else `false`.
      */
     function baseIsTypedArray(value) {
-      return isObjectLike(value) &&
-        isLength(value.length) && !!typedArrayTags[baseGetTag(value)];
+      return isObjectLike(value) && isLength(value.length) && !!typedArrayTags[baseGetTag(value)]
     }
 
     /**
@@ -3470,17 +3619,15 @@
       // Don't store the `typeof` result in a variable to avoid a JIT bug in Safari 9.
       // See https://bugs.webkit.org/show_bug.cgi?id=156034 for more details.
       if (typeof value == 'function') {
-        return value;
+        return value
       }
       if (value == null) {
-        return identity;
+        return identity
       }
       if (typeof value == 'object') {
-        return isArray(value)
-          ? baseMatchesProperty(value[0], value[1])
-          : baseMatches(value);
+        return isArray(value) ? baseMatchesProperty(value[0], value[1]) : baseMatches(value)
       }
-      return property(value);
+      return property(value)
     }
 
     /**
@@ -3492,15 +3639,15 @@
      */
     function baseKeys(object) {
       if (!isPrototype(object)) {
-        return nativeKeys(object);
+        return nativeKeys(object)
       }
-      var result = [];
+      var result = []
       for (var key in Object(object)) {
         if (hasOwnProperty.call(object, key) && key != 'constructor') {
-          result.push(key);
+          result.push(key)
         }
       }
-      return result;
+      return result
     }
 
     /**
@@ -3512,17 +3659,17 @@
      */
     function baseKeysIn(object) {
       if (!isObject(object)) {
-        return nativeKeysIn(object);
+        return nativeKeysIn(object)
       }
       var isProto = isPrototype(object),
-          result = [];
+        result = []
 
       for (var key in object) {
         if (!(key == 'constructor' && (isProto || !hasOwnProperty.call(object, key)))) {
-          result.push(key);
+          result.push(key)
         }
       }
-      return result;
+      return result
     }
 
     /**
@@ -3535,7 +3682,7 @@
      *  else `false`.
      */
     function baseLt(value, other) {
-      return value < other;
+      return value < other
     }
 
     /**
@@ -3548,12 +3695,12 @@
      */
     function baseMap(collection, iteratee) {
       var index = -1,
-          result = isArrayLike(collection) ? Array(collection.length) : [];
+        result = isArrayLike(collection) ? Array(collection.length) : []
 
       baseEach(collection, function(value, key, collection) {
-        result[++index] = iteratee(value, key, collection);
-      });
-      return result;
+        result[++index] = iteratee(value, key, collection)
+      })
+      return result
     }
 
     /**
@@ -3564,13 +3711,13 @@
      * @returns {Function} Returns the new spec function.
      */
     function baseMatches(source) {
-      var matchData = getMatchData(source);
+      var matchData = getMatchData(source)
       if (matchData.length == 1 && matchData[0][2]) {
-        return matchesStrictComparable(matchData[0][0], matchData[0][1]);
+        return matchesStrictComparable(matchData[0][0], matchData[0][1])
       }
       return function(object) {
-        return object === source || baseIsMatch(object, source, matchData);
-      };
+        return object === source || baseIsMatch(object, source, matchData)
+      }
     }
 
     /**
@@ -3583,14 +3730,14 @@
      */
     function baseMatchesProperty(path, srcValue) {
       if (isKey(path) && isStrictComparable(srcValue)) {
-        return matchesStrictComparable(toKey(path), srcValue);
+        return matchesStrictComparable(toKey(path), srcValue)
       }
       return function(object) {
-        var objValue = get(object, path);
-        return (objValue === undefined && objValue === srcValue)
+        var objValue = get(object, path)
+        return objValue === undefined && objValue === srcValue
           ? hasIn(object, path)
-          : baseIsEqual(srcValue, objValue, COMPARE_PARTIAL_FLAG | COMPARE_UNORDERED_FLAG);
-      };
+          : baseIsEqual(srcValue, objValue, COMPARE_PARTIAL_FLAG | COMPARE_UNORDERED_FLAG)
+      }
     }
 
     /**
@@ -3606,24 +3753,25 @@
      */
     function baseMerge(object, source, srcIndex, customizer, stack) {
       if (object === source) {
-        return;
+        return
       }
-      baseFor(source, function(srcValue, key) {
-        if (isObject(srcValue)) {
-          stack || (stack = new Stack);
-          baseMergeDeep(object, source, key, srcIndex, baseMerge, customizer, stack);
-        }
-        else {
-          var newValue = customizer
-            ? customizer(object[key], srcValue, (key + ''), object, source, stack)
-            : undefined;
+      baseFor(
+        source,
+        function(srcValue, key) {
+          if (isObject(srcValue)) {
+            stack || (stack = new Stack())
+            baseMergeDeep(object, source, key, srcIndex, baseMerge, customizer, stack)
+          } else {
+            var newValue = customizer ? customizer(object[key], srcValue, key + '', object, source, stack) : undefined
 
-          if (newValue === undefined) {
-            newValue = srcValue;
+            if (newValue === undefined) {
+              newValue = srcValue
+            }
+            assignMergeValue(object, key, newValue)
           }
-          assignMergeValue(object, key, newValue);
-        }
-      }, keysIn);
+        },
+        keysIn
+      )
     }
 
     /**
@@ -3643,64 +3791,55 @@
      */
     function baseMergeDeep(object, source, key, srcIndex, mergeFunc, customizer, stack) {
       var objValue = object[key],
-          srcValue = source[key],
-          stacked = stack.get(srcValue);
+        srcValue = source[key],
+        stacked = stack.get(srcValue)
 
       if (stacked) {
-        assignMergeValue(object, key, stacked);
-        return;
+        assignMergeValue(object, key, stacked)
+        return
       }
-      var newValue = customizer
-        ? customizer(objValue, srcValue, (key + ''), object, source, stack)
-        : undefined;
+      var newValue = customizer ? customizer(objValue, srcValue, key + '', object, source, stack) : undefined
 
-      var isCommon = newValue === undefined;
+      var isCommon = newValue === undefined
 
       if (isCommon) {
         var isArr = isArray(srcValue),
-            isBuff = !isArr && isBuffer(srcValue),
-            isTyped = !isArr && !isBuff && isTypedArray(srcValue);
+          isBuff = !isArr && isBuffer(srcValue),
+          isTyped = !isArr && !isBuff && isTypedArray(srcValue)
 
-        newValue = srcValue;
+        newValue = srcValue
         if (isArr || isBuff || isTyped) {
           if (isArray(objValue)) {
-            newValue = objValue;
+            newValue = objValue
+          } else if (isArrayLikeObject(objValue)) {
+            newValue = copyArray(objValue)
+          } else if (isBuff) {
+            isCommon = false
+            newValue = cloneBuffer(srcValue, true)
+          } else if (isTyped) {
+            isCommon = false
+            newValue = cloneTypedArray(srcValue, true)
+          } else {
+            newValue = []
           }
-          else if (isArrayLikeObject(objValue)) {
-            newValue = copyArray(objValue);
-          }
-          else if (isBuff) {
-            isCommon = false;
-            newValue = cloneBuffer(srcValue, true);
-          }
-          else if (isTyped) {
-            isCommon = false;
-            newValue = cloneTypedArray(srcValue, true);
-          }
-          else {
-            newValue = [];
-          }
-        }
-        else if (isPlainObject(srcValue) || isArguments(srcValue)) {
-          newValue = objValue;
+        } else if (isPlainObject(srcValue) || isArguments(srcValue)) {
+          newValue = objValue
           if (isArguments(objValue)) {
-            newValue = toPlainObject(objValue);
+            newValue = toPlainObject(objValue)
+          } else if (!isObject(objValue) || (srcIndex && isFunction(objValue))) {
+            newValue = initCloneObject(srcValue)
           }
-          else if (!isObject(objValue) || (srcIndex && isFunction(objValue))) {
-            newValue = initCloneObject(srcValue);
-          }
-        }
-        else {
-          isCommon = false;
+        } else {
+          isCommon = false
         }
       }
       if (isCommon) {
         // Recursively merge objects and arrays (susceptible to call stack limits).
-        stack.set(srcValue, newValue);
-        mergeFunc(newValue, srcValue, srcIndex, customizer, stack);
-        stack['delete'](srcValue);
+        stack.set(srcValue, newValue)
+        mergeFunc(newValue, srcValue, srcIndex, customizer, stack)
+        stack['delete'](srcValue)
       }
-      assignMergeValue(object, key, newValue);
+      assignMergeValue(object, key, newValue)
     }
 
     /**
@@ -3712,12 +3851,12 @@
      * @returns {*} Returns the nth element of `array`.
      */
     function baseNth(array, n) {
-      var length = array.length;
+      var length = array.length
       if (!length) {
-        return;
+        return
       }
-      n += n < 0 ? length : 0;
-      return isIndex(n, length) ? array[n] : undefined;
+      n += n < 0 ? length : 0
+      return isIndex(n, length) ? array[n] : undefined
     }
 
     /**
@@ -3730,19 +3869,19 @@
      * @returns {Array} Returns the new sorted array.
      */
     function baseOrderBy(collection, iteratees, orders) {
-      var index = -1;
-      iteratees = arrayMap(iteratees.length ? iteratees : [identity], baseUnary(getIteratee()));
+      var index = -1
+      iteratees = arrayMap(iteratees.length ? iteratees : [identity], baseUnary(getIteratee()))
 
       var result = baseMap(collection, function(value, key, collection) {
         var criteria = arrayMap(iteratees, function(iteratee) {
-          return iteratee(value);
-        });
-        return { 'criteria': criteria, 'index': ++index, 'value': value };
-      });
+          return iteratee(value)
+        })
+        return {criteria: criteria, index: ++index, value: value}
+      })
 
       return baseSortBy(result, function(object, other) {
-        return compareMultiple(object, other, orders);
-      });
+        return compareMultiple(object, other, orders)
+      })
     }
 
     /**
@@ -3756,8 +3895,8 @@
      */
     function basePick(object, paths) {
       return basePickBy(object, paths, function(value, path) {
-        return hasIn(object, path);
-      });
+        return hasIn(object, path)
+      })
     }
 
     /**
@@ -3771,18 +3910,18 @@
      */
     function basePickBy(object, paths, predicate) {
       var index = -1,
-          length = paths.length,
-          result = {};
+        length = paths.length,
+        result = {}
 
       while (++index < length) {
         var path = paths[index],
-            value = baseGet(object, path);
+          value = baseGet(object, path)
 
         if (predicate(value, path)) {
-          baseSet(result, castPath(path, object), value);
+          baseSet(result, castPath(path, object), value)
         }
       }
-      return result;
+      return result
     }
 
     /**
@@ -3794,8 +3933,8 @@
      */
     function basePropertyDeep(path) {
       return function(object) {
-        return baseGet(object, path);
-      };
+        return baseGet(object, path)
+      }
     }
 
     /**
@@ -3811,29 +3950,29 @@
      */
     function basePullAll(array, values, iteratee, comparator) {
       var indexOf = comparator ? baseIndexOfWith : baseIndexOf,
-          index = -1,
-          length = values.length,
-          seen = array;
+        index = -1,
+        length = values.length,
+        seen = array
 
       if (array === values) {
-        values = copyArray(values);
+        values = copyArray(values)
       }
       if (iteratee) {
-        seen = arrayMap(array, baseUnary(iteratee));
+        seen = arrayMap(array, baseUnary(iteratee))
       }
       while (++index < length) {
         var fromIndex = 0,
-            value = values[index],
-            computed = iteratee ? iteratee(value) : value;
+          value = values[index],
+          computed = iteratee ? iteratee(value) : value
 
         while ((fromIndex = indexOf(seen, computed, fromIndex, comparator)) > -1) {
           if (seen !== array) {
-            splice.call(seen, fromIndex, 1);
+            splice.call(seen, fromIndex, 1)
           }
-          splice.call(array, fromIndex, 1);
+          splice.call(array, fromIndex, 1)
         }
       }
-      return array;
+      return array
     }
 
     /**
@@ -3847,20 +3986,20 @@
      */
     function basePullAt(array, indexes) {
       var length = array ? indexes.length : 0,
-          lastIndex = length - 1;
+        lastIndex = length - 1
 
       while (length--) {
-        var index = indexes[length];
+        var index = indexes[length]
         if (length == lastIndex || index !== previous) {
-          var previous = index;
+          var previous = index
           if (isIndex(index)) {
-            splice.call(array, index, 1);
+            splice.call(array, index, 1)
           } else {
-            baseUnset(array, index);
+            baseUnset(array, index)
           }
         }
       }
-      return array;
+      return array
     }
 
     /**
@@ -3873,7 +4012,7 @@
      * @returns {number} Returns the random number.
      */
     function baseRandom(lower, upper) {
-      return lower + nativeFloor(nativeRandom() * (upper - lower + 1));
+      return lower + nativeFloor(nativeRandom() * (upper - lower + 1))
     }
 
     /**
@@ -3889,14 +4028,14 @@
      */
     function baseRange(start, end, step, fromRight) {
       var index = -1,
-          length = nativeMax(nativeCeil((end - start) / (step || 1)), 0),
-          result = Array(length);
+        length = nativeMax(nativeCeil((end - start) / (step || 1)), 0),
+        result = Array(length)
 
       while (length--) {
-        result[fromRight ? length : ++index] = start;
-        start += step;
+        result[fromRight ? length : ++index] = start
+        start += step
       }
-      return result;
+      return result
     }
 
     /**
@@ -3908,23 +4047,23 @@
      * @returns {string} Returns the repeated string.
      */
     function baseRepeat(string, n) {
-      var result = '';
+      var result = ''
       if (!string || n < 1 || n > MAX_SAFE_INTEGER) {
-        return result;
+        return result
       }
       // Leverage the exponentiation by squaring algorithm for a faster repeat.
       // See https://en.wikipedia.org/wiki/Exponentiation_by_squaring for more details.
       do {
         if (n % 2) {
-          result += string;
+          result += string
         }
-        n = nativeFloor(n / 2);
+        n = nativeFloor(n / 2)
         if (n) {
-          string += string;
+          string += string
         }
-      } while (n);
+      } while (n)
 
-      return result;
+      return result
     }
 
     /**
@@ -3936,7 +4075,7 @@
      * @returns {Function} Returns the new function.
      */
     function baseRest(func, start) {
-      return setToString(overRest(func, start, identity), func + '');
+      return setToString(overRest(func, start, identity), func + '')
     }
 
     /**
@@ -3947,7 +4086,7 @@
      * @returns {*} Returns the random element.
      */
     function baseSample(collection) {
-      return arraySample(values(collection));
+      return arraySample(values(collection))
     }
 
     /**
@@ -3959,8 +4098,8 @@
      * @returns {Array} Returns the random elements.
      */
     function baseSampleSize(collection, n) {
-      var array = values(collection);
-      return shuffleSelf(array, baseClamp(n, 0, array.length));
+      var array = values(collection)
+      return shuffleSelf(array, baseClamp(n, 0, array.length))
     }
 
     /**
@@ -3975,32 +4114,30 @@
      */
     function baseSet(object, path, value, customizer) {
       if (!isObject(object)) {
-        return object;
+        return object
       }
-      path = castPath(path, object);
+      path = castPath(path, object)
 
       var index = -1,
-          length = path.length,
-          lastIndex = length - 1,
-          nested = object;
+        length = path.length,
+        lastIndex = length - 1,
+        nested = object
 
       while (nested != null && ++index < length) {
         var key = toKey(path[index]),
-            newValue = value;
+          newValue = value
 
         if (index != lastIndex) {
-          var objValue = nested[key];
-          newValue = customizer ? customizer(objValue, key, nested) : undefined;
+          var objValue = nested[key]
+          newValue = customizer ? customizer(objValue, key, nested) : undefined
           if (newValue === undefined) {
-            newValue = isObject(objValue)
-              ? objValue
-              : (isIndex(path[index + 1]) ? [] : {});
+            newValue = isObject(objValue) ? objValue : isIndex(path[index + 1]) ? [] : {}
           }
         }
-        assignValue(nested, key, newValue);
-        nested = nested[key];
+        assignValue(nested, key, newValue)
+        nested = nested[key]
       }
-      return object;
+      return object
     }
 
     /**
@@ -4011,10 +4148,12 @@
      * @param {*} data The metadata.
      * @returns {Function} Returns `func`.
      */
-    var baseSetData = !metaMap ? identity : function(func, data) {
-      metaMap.set(func, data);
-      return func;
-    };
+    var baseSetData = !metaMap
+      ? identity
+      : function(func, data) {
+          metaMap.set(func, data)
+          return func
+        }
 
     /**
      * The base implementation of `setToString` without support for hot loop shorting.
@@ -4024,14 +4163,16 @@
      * @param {Function} string The `toString` result.
      * @returns {Function} Returns `func`.
      */
-    var baseSetToString = !defineProperty ? identity : function(func, string) {
-      return defineProperty(func, 'toString', {
-        'configurable': true,
-        'enumerable': false,
-        'value': constant(string),
-        'writable': true
-      });
-    };
+    var baseSetToString = !defineProperty
+      ? identity
+      : function(func, string) {
+          return defineProperty(func, 'toString', {
+            configurable: true,
+            enumerable: false,
+            value: constant(string),
+            writable: true
+          })
+        }
 
     /**
      * The base implementation of `_.shuffle`.
@@ -4041,7 +4182,7 @@
      * @returns {Array} Returns the new shuffled array.
      */
     function baseShuffle(collection) {
-      return shuffleSelf(values(collection));
+      return shuffleSelf(values(collection))
     }
 
     /**
@@ -4055,23 +4196,23 @@
      */
     function baseSlice(array, start, end) {
       var index = -1,
-          length = array.length;
+        length = array.length
 
       if (start < 0) {
-        start = -start > length ? 0 : (length + start);
+        start = -start > length ? 0 : length + start
       }
-      end = end > length ? length : end;
+      end = end > length ? length : end
       if (end < 0) {
-        end += length;
+        end += length
       }
-      length = start > end ? 0 : ((end - start) >>> 0);
-      start >>>= 0;
+      length = start > end ? 0 : (end - start) >>> 0
+      start >>>= 0
 
-      var result = Array(length);
+      var result = Array(length)
       while (++index < length) {
-        result[index] = array[index + start];
+        result[index] = array[index + start]
       }
-      return result;
+      return result
     }
 
     /**
@@ -4084,13 +4225,13 @@
      *  else `false`.
      */
     function baseSome(collection, predicate) {
-      var result;
+      var result
 
       baseEach(collection, function(value, index, collection) {
-        result = predicate(value, index, collection);
-        return !result;
-      });
-      return !!result;
+        result = predicate(value, index, collection)
+        return !result
+      })
+      return !!result
     }
 
     /**
@@ -4107,23 +4248,22 @@
      */
     function baseSortedIndex(array, value, retHighest) {
       var low = 0,
-          high = array == null ? low : array.length;
+        high = array == null ? low : array.length
 
       if (typeof value == 'number' && value === value && high <= HALF_MAX_ARRAY_LENGTH) {
         while (low < high) {
           var mid = (low + high) >>> 1,
-              computed = array[mid];
+            computed = array[mid]
 
-          if (computed !== null && !isSymbol(computed) &&
-              (retHighest ? (computed <= value) : (computed < value))) {
-            low = mid + 1;
+          if (computed !== null && !isSymbol(computed) && (retHighest ? computed <= value : computed < value)) {
+            low = mid + 1
           } else {
-            high = mid;
+            high = mid
           }
         }
-        return high;
+        return high
       }
-      return baseSortedIndexBy(array, value, identity, retHighest);
+      return baseSortedIndexBy(array, value, identity, retHighest)
     }
 
     /**
@@ -4140,43 +4280,43 @@
      *  into `array`.
      */
     function baseSortedIndexBy(array, value, iteratee, retHighest) {
-      value = iteratee(value);
+      value = iteratee(value)
 
       var low = 0,
-          high = array == null ? 0 : array.length,
-          valIsNaN = value !== value,
-          valIsNull = value === null,
-          valIsSymbol = isSymbol(value),
-          valIsUndefined = value === undefined;
+        high = array == null ? 0 : array.length,
+        valIsNaN = value !== value,
+        valIsNull = value === null,
+        valIsSymbol = isSymbol(value),
+        valIsUndefined = value === undefined
 
       while (low < high) {
         var mid = nativeFloor((low + high) / 2),
-            computed = iteratee(array[mid]),
-            othIsDefined = computed !== undefined,
-            othIsNull = computed === null,
-            othIsReflexive = computed === computed,
-            othIsSymbol = isSymbol(computed);
+          computed = iteratee(array[mid]),
+          othIsDefined = computed !== undefined,
+          othIsNull = computed === null,
+          othIsReflexive = computed === computed,
+          othIsSymbol = isSymbol(computed)
 
         if (valIsNaN) {
-          var setLow = retHighest || othIsReflexive;
+          var setLow = retHighest || othIsReflexive
         } else if (valIsUndefined) {
-          setLow = othIsReflexive && (retHighest || othIsDefined);
+          setLow = othIsReflexive && (retHighest || othIsDefined)
         } else if (valIsNull) {
-          setLow = othIsReflexive && othIsDefined && (retHighest || !othIsNull);
+          setLow = othIsReflexive && othIsDefined && (retHighest || !othIsNull)
         } else if (valIsSymbol) {
-          setLow = othIsReflexive && othIsDefined && !othIsNull && (retHighest || !othIsSymbol);
+          setLow = othIsReflexive && othIsDefined && !othIsNull && (retHighest || !othIsSymbol)
         } else if (othIsNull || othIsSymbol) {
-          setLow = false;
+          setLow = false
         } else {
-          setLow = retHighest ? (computed <= value) : (computed < value);
+          setLow = retHighest ? computed <= value : computed < value
         }
         if (setLow) {
-          low = mid + 1;
+          low = mid + 1
         } else {
-          high = mid;
+          high = mid
         }
       }
-      return nativeMin(high, MAX_ARRAY_INDEX);
+      return nativeMin(high, MAX_ARRAY_INDEX)
     }
 
     /**
@@ -4190,20 +4330,20 @@
      */
     function baseSortedUniq(array, iteratee) {
       var index = -1,
-          length = array.length,
-          resIndex = 0,
-          result = [];
+        length = array.length,
+        resIndex = 0,
+        result = []
 
       while (++index < length) {
         var value = array[index],
-            computed = iteratee ? iteratee(value) : value;
+          computed = iteratee ? iteratee(value) : value
 
         if (!index || !eq(computed, seen)) {
-          var seen = computed;
-          result[resIndex++] = value === 0 ? 0 : value;
+          var seen = computed
+          result[resIndex++] = value === 0 ? 0 : value
         }
       }
-      return result;
+      return result
     }
 
     /**
@@ -4216,12 +4356,12 @@
      */
     function baseToNumber(value) {
       if (typeof value == 'number') {
-        return value;
+        return value
       }
       if (isSymbol(value)) {
-        return NAN;
+        return NAN
       }
-      return +value;
+      return +value
     }
 
     /**
@@ -4235,17 +4375,17 @@
     function baseToString(value) {
       // Exit early for strings to avoid a performance hit in some environments.
       if (typeof value == 'string') {
-        return value;
+        return value
       }
       if (isArray(value)) {
         // Recursively convert values (susceptible to call stack limits).
-        return arrayMap(value, baseToString) + '';
+        return arrayMap(value, baseToString) + ''
       }
       if (isSymbol(value)) {
-        return symbolToString ? symbolToString.call(value) : '';
+        return symbolToString ? symbolToString.call(value) : ''
       }
-      var result = (value + '');
-      return (result == '0' && (1 / value) == -INFINITY) ? '-0' : result;
+      var result = value + ''
+      return result == '0' && 1 / value == -INFINITY ? '-0' : result
     }
 
     /**
@@ -4259,54 +4399,50 @@
      */
     function baseUniq(array, iteratee, comparator) {
       var index = -1,
-          includes = arrayIncludes,
-          length = array.length,
-          isCommon = true,
-          result = [],
-          seen = result;
+        includes = arrayIncludes,
+        length = array.length,
+        isCommon = true,
+        result = [],
+        seen = result
 
       if (comparator) {
-        isCommon = false;
-        includes = arrayIncludesWith;
-      }
-      else if (length >= LARGE_ARRAY_SIZE) {
-        var set = iteratee ? null : createSet(array);
+        isCommon = false
+        includes = arrayIncludesWith
+      } else if (length >= LARGE_ARRAY_SIZE) {
+        var set = iteratee ? null : createSet(array)
         if (set) {
-          return setToArray(set);
+          return setToArray(set)
         }
-        isCommon = false;
-        includes = cacheHas;
-        seen = new SetCache;
+        isCommon = false
+        includes = cacheHas
+        seen = new SetCache()
+      } else {
+        seen = iteratee ? [] : result
       }
-      else {
-        seen = iteratee ? [] : result;
-      }
-      outer:
-      while (++index < length) {
+      outer: while (++index < length) {
         var value = array[index],
-            computed = iteratee ? iteratee(value) : value;
+          computed = iteratee ? iteratee(value) : value
 
-        value = (comparator || value !== 0) ? value : 0;
+        value = comparator || value !== 0 ? value : 0
         if (isCommon && computed === computed) {
-          var seenIndex = seen.length;
+          var seenIndex = seen.length
           while (seenIndex--) {
             if (seen[seenIndex] === computed) {
-              continue outer;
+              continue outer
             }
           }
           if (iteratee) {
-            seen.push(computed);
+            seen.push(computed)
           }
-          result.push(value);
-        }
-        else if (!includes(seen, computed, comparator)) {
+          result.push(value)
+        } else if (!includes(seen, computed, comparator)) {
           if (seen !== result) {
-            seen.push(computed);
+            seen.push(computed)
           }
-          result.push(value);
+          result.push(value)
         }
       }
-      return result;
+      return result
     }
 
     /**
@@ -4318,9 +4454,9 @@
      * @returns {boolean} Returns `true` if the property is deleted, else `false`.
      */
     function baseUnset(object, path) {
-      path = castPath(path, object);
-      object = parent(object, path);
-      return object == null || delete object[toKey(last(path))];
+      path = castPath(path, object)
+      object = parent(object, path)
+      return object == null || delete object[toKey(last(path))]
     }
 
     /**
@@ -4334,7 +4470,7 @@
      * @returns {Object} Returns `object`.
      */
     function baseUpdate(object, path, updater, customizer) {
-      return baseSet(object, path, updater(baseGet(object, path)), customizer);
+      return baseSet(object, path, updater(baseGet(object, path)), customizer)
     }
 
     /**
@@ -4350,14 +4486,13 @@
      */
     function baseWhile(array, predicate, isDrop, fromRight) {
       var length = array.length,
-          index = fromRight ? length : -1;
+        index = fromRight ? length : -1
 
-      while ((fromRight ? index-- : ++index < length) &&
-        predicate(array[index], index, array)) {}
+      while ((fromRight ? index-- : ++index < length) && predicate(array[index], index, array)) {}
 
       return isDrop
-        ? baseSlice(array, (fromRight ? 0 : index), (fromRight ? index + 1 : length))
-        : baseSlice(array, (fromRight ? index + 1 : 0), (fromRight ? length : index));
+        ? baseSlice(array, fromRight ? 0 : index, fromRight ? index + 1 : length)
+        : baseSlice(array, fromRight ? index + 1 : 0, fromRight ? length : index)
     }
 
     /**
@@ -4371,13 +4506,17 @@
      * @returns {*} Returns the resolved value.
      */
     function baseWrapperValue(value, actions) {
-      var result = value;
+      var result = value
       if (result instanceof LazyWrapper) {
-        result = result.value();
+        result = result.value()
       }
-      return arrayReduce(actions, function(result, action) {
-        return action.func.apply(action.thisArg, arrayPush([result], action.args));
-      }, result);
+      return arrayReduce(
+        actions,
+        function(result, action) {
+          return action.func.apply(action.thisArg, arrayPush([result], action.args))
+        },
+        result
+      )
     }
 
     /**
@@ -4391,24 +4530,24 @@
      * @returns {Array} Returns the new array of values.
      */
     function baseXor(arrays, iteratee, comparator) {
-      var length = arrays.length;
+      var length = arrays.length
       if (length < 2) {
-        return length ? baseUniq(arrays[0]) : [];
+        return length ? baseUniq(arrays[0]) : []
       }
       var index = -1,
-          result = Array(length);
+        result = Array(length)
 
       while (++index < length) {
         var array = arrays[index],
-            othIndex = -1;
+          othIndex = -1
 
         while (++othIndex < length) {
           if (othIndex != index) {
-            result[index] = baseDifference(result[index] || array, arrays[othIndex], iteratee, comparator);
+            result[index] = baseDifference(result[index] || array, arrays[othIndex], iteratee, comparator)
           }
         }
       }
-      return baseUniq(baseFlatten(result, 1), iteratee, comparator);
+      return baseUniq(baseFlatten(result, 1), iteratee, comparator)
     }
 
     /**
@@ -4422,15 +4561,15 @@
      */
     function baseZipObject(props, values, assignFunc) {
       var index = -1,
-          length = props.length,
-          valsLength = values.length,
-          result = {};
+        length = props.length,
+        valsLength = values.length,
+        result = {}
 
       while (++index < length) {
-        var value = index < valsLength ? values[index] : undefined;
-        assignFunc(result, props[index], value);
+        var value = index < valsLength ? values[index] : undefined
+        assignFunc(result, props[index], value)
       }
-      return result;
+      return result
     }
 
     /**
@@ -4441,7 +4580,7 @@
      * @returns {Array|Object} Returns the cast array-like object.
      */
     function castArrayLikeObject(value) {
-      return isArrayLikeObject(value) ? value : [];
+      return isArrayLikeObject(value) ? value : []
     }
 
     /**
@@ -4452,7 +4591,7 @@
      * @returns {Function} Returns cast function.
      */
     function castFunction(value) {
-      return typeof value == 'function' ? value : identity;
+      return typeof value == 'function' ? value : identity
     }
 
     /**
@@ -4465,9 +4604,9 @@
      */
     function castPath(value, object) {
       if (isArray(value)) {
-        return value;
+        return value
       }
-      return isKey(value, object) ? [value] : stringToPath(toString(value));
+      return isKey(value, object) ? [value] : stringToPath(toString(value))
     }
 
     /**
@@ -4479,7 +4618,7 @@
      * @param {Function} func The function to apply a rest parameter to.
      * @returns {Function} Returns the new function.
      */
-    var castRest = baseRest;
+    var castRest = baseRest
 
     /**
      * Casts `array` to a slice if it's needed.
@@ -4491,9 +4630,9 @@
      * @returns {Array} Returns the cast slice.
      */
     function castSlice(array, start, end) {
-      var length = array.length;
-      end = end === undefined ? length : end;
-      return (!start && end >= length) ? array : baseSlice(array, start, end);
+      var length = array.length
+      end = end === undefined ? length : end
+      return !start && end >= length ? array : baseSlice(array, start, end)
     }
 
     /**
@@ -4502,9 +4641,11 @@
      * @private
      * @param {number|Object} id The timer id or timeout object of the timer to clear.
      */
-    var clearTimeout = ctxClearTimeout || function(id) {
-      return root.clearTimeout(id);
-    };
+    var clearTimeout =
+      ctxClearTimeout ||
+      function(id) {
+        return root.clearTimeout(id)
+      }
 
     /**
      * Creates a clone of  `buffer`.
@@ -4516,13 +4657,13 @@
      */
     function cloneBuffer(buffer, isDeep) {
       if (isDeep) {
-        return buffer.slice();
+        return buffer.slice()
       }
       var length = buffer.length,
-          result = allocUnsafe ? allocUnsafe(length) : new buffer.constructor(length);
+        result = allocUnsafe ? allocUnsafe(length) : new buffer.constructor(length)
 
-      buffer.copy(result);
-      return result;
+      buffer.copy(result)
+      return result
     }
 
     /**
@@ -4533,9 +4674,9 @@
      * @returns {ArrayBuffer} Returns the cloned array buffer.
      */
     function cloneArrayBuffer(arrayBuffer) {
-      var result = new arrayBuffer.constructor(arrayBuffer.byteLength);
-      new Uint8Array(result).set(new Uint8Array(arrayBuffer));
-      return result;
+      var result = new arrayBuffer.constructor(arrayBuffer.byteLength)
+      new Uint8Array(result).set(new Uint8Array(arrayBuffer))
+      return result
     }
 
     /**
@@ -4547,8 +4688,8 @@
      * @returns {Object} Returns the cloned data view.
      */
     function cloneDataView(dataView, isDeep) {
-      var buffer = isDeep ? cloneArrayBuffer(dataView.buffer) : dataView.buffer;
-      return new dataView.constructor(buffer, dataView.byteOffset, dataView.byteLength);
+      var buffer = isDeep ? cloneArrayBuffer(dataView.buffer) : dataView.buffer
+      return new dataView.constructor(buffer, dataView.byteOffset, dataView.byteLength)
     }
 
     /**
@@ -4561,8 +4702,8 @@
      * @returns {Object} Returns the cloned map.
      */
     function cloneMap(map, isDeep, cloneFunc) {
-      var array = isDeep ? cloneFunc(mapToArray(map), CLONE_DEEP_FLAG) : mapToArray(map);
-      return arrayReduce(array, addMapEntry, new map.constructor);
+      var array = isDeep ? cloneFunc(mapToArray(map), CLONE_DEEP_FLAG) : mapToArray(map)
+      return arrayReduce(array, addMapEntry, new map.constructor())
     }
 
     /**
@@ -4573,9 +4714,9 @@
      * @returns {Object} Returns the cloned regexp.
      */
     function cloneRegExp(regexp) {
-      var result = new regexp.constructor(regexp.source, reFlags.exec(regexp));
-      result.lastIndex = regexp.lastIndex;
-      return result;
+      var result = new regexp.constructor(regexp.source, reFlags.exec(regexp))
+      result.lastIndex = regexp.lastIndex
+      return result
     }
 
     /**
@@ -4588,8 +4729,8 @@
      * @returns {Object} Returns the cloned set.
      */
     function cloneSet(set, isDeep, cloneFunc) {
-      var array = isDeep ? cloneFunc(setToArray(set), CLONE_DEEP_FLAG) : setToArray(set);
-      return arrayReduce(array, addSetEntry, new set.constructor);
+      var array = isDeep ? cloneFunc(setToArray(set), CLONE_DEEP_FLAG) : setToArray(set)
+      return arrayReduce(array, addSetEntry, new set.constructor())
     }
 
     /**
@@ -4600,7 +4741,7 @@
      * @returns {Object} Returns the cloned symbol object.
      */
     function cloneSymbol(symbol) {
-      return symbolValueOf ? Object(symbolValueOf.call(symbol)) : {};
+      return symbolValueOf ? Object(symbolValueOf.call(symbol)) : {}
     }
 
     /**
@@ -4612,8 +4753,8 @@
      * @returns {Object} Returns the cloned typed array.
      */
     function cloneTypedArray(typedArray, isDeep) {
-      var buffer = isDeep ? cloneArrayBuffer(typedArray.buffer) : typedArray.buffer;
-      return new typedArray.constructor(buffer, typedArray.byteOffset, typedArray.length);
+      var buffer = isDeep ? cloneArrayBuffer(typedArray.buffer) : typedArray.buffer
+      return new typedArray.constructor(buffer, typedArray.byteOffset, typedArray.length)
     }
 
     /**
@@ -4627,31 +4768,35 @@
     function compareAscending(value, other) {
       if (value !== other) {
         var valIsDefined = value !== undefined,
-            valIsNull = value === null,
-            valIsReflexive = value === value,
-            valIsSymbol = isSymbol(value);
+          valIsNull = value === null,
+          valIsReflexive = value === value,
+          valIsSymbol = isSymbol(value)
 
         var othIsDefined = other !== undefined,
-            othIsNull = other === null,
-            othIsReflexive = other === other,
-            othIsSymbol = isSymbol(other);
+          othIsNull = other === null,
+          othIsReflexive = other === other,
+          othIsSymbol = isSymbol(other)
 
-        if ((!othIsNull && !othIsSymbol && !valIsSymbol && value > other) ||
-            (valIsSymbol && othIsDefined && othIsReflexive && !othIsNull && !othIsSymbol) ||
-            (valIsNull && othIsDefined && othIsReflexive) ||
-            (!valIsDefined && othIsReflexive) ||
-            !valIsReflexive) {
-          return 1;
+        if (
+          (!othIsNull && !othIsSymbol && !valIsSymbol && value > other) ||
+          (valIsSymbol && othIsDefined && othIsReflexive && !othIsNull && !othIsSymbol) ||
+          (valIsNull && othIsDefined && othIsReflexive) ||
+          (!valIsDefined && othIsReflexive) ||
+          !valIsReflexive
+        ) {
+          return 1
         }
-        if ((!valIsNull && !valIsSymbol && !othIsSymbol && value < other) ||
-            (othIsSymbol && valIsDefined && valIsReflexive && !valIsNull && !valIsSymbol) ||
-            (othIsNull && valIsDefined && valIsReflexive) ||
-            (!othIsDefined && valIsReflexive) ||
-            !othIsReflexive) {
-          return -1;
+        if (
+          (!valIsNull && !valIsSymbol && !othIsSymbol && value < other) ||
+          (othIsSymbol && valIsDefined && valIsReflexive && !valIsNull && !valIsSymbol) ||
+          (othIsNull && valIsDefined && valIsReflexive) ||
+          (!othIsDefined && valIsReflexive) ||
+          !othIsReflexive
+        ) {
+          return -1
         }
       }
-      return 0;
+      return 0
     }
 
     /**
@@ -4670,19 +4815,19 @@
      */
     function compareMultiple(object, other, orders) {
       var index = -1,
-          objCriteria = object.criteria,
-          othCriteria = other.criteria,
-          length = objCriteria.length,
-          ordersLength = orders.length;
+        objCriteria = object.criteria,
+        othCriteria = other.criteria,
+        length = objCriteria.length,
+        ordersLength = orders.length
 
       while (++index < length) {
-        var result = compareAscending(objCriteria[index], othCriteria[index]);
+        var result = compareAscending(objCriteria[index], othCriteria[index])
         if (result) {
           if (index >= ordersLength) {
-            return result;
+            return result
           }
-          var order = orders[index];
-          return result * (order == 'desc' ? -1 : 1);
+          var order = orders[index]
+          return result * (order == 'desc' ? -1 : 1)
         }
       }
       // Fixes an `Array#sort` bug in the JS engine embedded in Adobe applications
@@ -4692,7 +4837,7 @@
       //
       // This also ensures a stable sort in V8 and other engines.
       // See https://bugs.chromium.org/p/v8/issues/detail?id=90 for more details.
-      return object.index - other.index;
+      return object.index - other.index
     }
 
     /**
@@ -4708,26 +4853,26 @@
      */
     function composeArgs(args, partials, holders, isCurried) {
       var argsIndex = -1,
-          argsLength = args.length,
-          holdersLength = holders.length,
-          leftIndex = -1,
-          leftLength = partials.length,
-          rangeLength = nativeMax(argsLength - holdersLength, 0),
-          result = Array(leftLength + rangeLength),
-          isUncurried = !isCurried;
+        argsLength = args.length,
+        holdersLength = holders.length,
+        leftIndex = -1,
+        leftLength = partials.length,
+        rangeLength = nativeMax(argsLength - holdersLength, 0),
+        result = Array(leftLength + rangeLength),
+        isUncurried = !isCurried
 
       while (++leftIndex < leftLength) {
-        result[leftIndex] = partials[leftIndex];
+        result[leftIndex] = partials[leftIndex]
       }
       while (++argsIndex < holdersLength) {
         if (isUncurried || argsIndex < argsLength) {
-          result[holders[argsIndex]] = args[argsIndex];
+          result[holders[argsIndex]] = args[argsIndex]
         }
       }
       while (rangeLength--) {
-        result[leftIndex++] = args[argsIndex++];
+        result[leftIndex++] = args[argsIndex++]
       }
-      return result;
+      return result
     }
 
     /**
@@ -4743,28 +4888,28 @@
      */
     function composeArgsRight(args, partials, holders, isCurried) {
       var argsIndex = -1,
-          argsLength = args.length,
-          holdersIndex = -1,
-          holdersLength = holders.length,
-          rightIndex = -1,
-          rightLength = partials.length,
-          rangeLength = nativeMax(argsLength - holdersLength, 0),
-          result = Array(rangeLength + rightLength),
-          isUncurried = !isCurried;
+        argsLength = args.length,
+        holdersIndex = -1,
+        holdersLength = holders.length,
+        rightIndex = -1,
+        rightLength = partials.length,
+        rangeLength = nativeMax(argsLength - holdersLength, 0),
+        result = Array(rangeLength + rightLength),
+        isUncurried = !isCurried
 
       while (++argsIndex < rangeLength) {
-        result[argsIndex] = args[argsIndex];
+        result[argsIndex] = args[argsIndex]
       }
-      var offset = argsIndex;
+      var offset = argsIndex
       while (++rightIndex < rightLength) {
-        result[offset + rightIndex] = partials[rightIndex];
+        result[offset + rightIndex] = partials[rightIndex]
       }
       while (++holdersIndex < holdersLength) {
         if (isUncurried || argsIndex < argsLength) {
-          result[offset + holders[holdersIndex]] = args[argsIndex++];
+          result[offset + holders[holdersIndex]] = args[argsIndex++]
         }
       }
-      return result;
+      return result
     }
 
     /**
@@ -4777,13 +4922,13 @@
      */
     function copyArray(source, array) {
       var index = -1,
-          length = source.length;
+        length = source.length
 
-      array || (array = Array(length));
+      array || (array = Array(length))
       while (++index < length) {
-        array[index] = source[index];
+        array[index] = source[index]
       }
-      return array;
+      return array
     }
 
     /**
@@ -4797,29 +4942,27 @@
      * @returns {Object} Returns `object`.
      */
     function copyObject(source, props, object, customizer) {
-      var isNew = !object;
-      object || (object = {});
+      var isNew = !object
+      object || (object = {})
 
       var index = -1,
-          length = props.length;
+        length = props.length
 
       while (++index < length) {
-        var key = props[index];
+        var key = props[index]
 
-        var newValue = customizer
-          ? customizer(object[key], source[key], key, object, source)
-          : undefined;
+        var newValue = customizer ? customizer(object[key], source[key], key, object, source) : undefined
 
         if (newValue === undefined) {
-          newValue = source[key];
+          newValue = source[key]
         }
         if (isNew) {
-          baseAssignValue(object, key, newValue);
+          baseAssignValue(object, key, newValue)
         } else {
-          assignValue(object, key, newValue);
+          assignValue(object, key, newValue)
         }
       }
-      return object;
+      return object
     }
 
     /**
@@ -4831,7 +4974,7 @@
      * @returns {Object} Returns `object`.
      */
     function copySymbols(source, object) {
-      return copyObject(source, getSymbols(source), object);
+      return copyObject(source, getSymbols(source), object)
     }
 
     /**
@@ -4843,7 +4986,7 @@
      * @returns {Object} Returns `object`.
      */
     function copySymbolsIn(source, object) {
-      return copyObject(source, getSymbolsIn(source), object);
+      return copyObject(source, getSymbolsIn(source), object)
     }
 
     /**
@@ -4857,10 +5000,10 @@
     function createAggregator(setter, initializer) {
       return function(collection, iteratee) {
         var func = isArray(collection) ? arrayAggregator : baseAggregator,
-            accumulator = initializer ? initializer() : {};
+          accumulator = initializer ? initializer() : {}
 
-        return func(collection, setter, getIteratee(iteratee, 2), accumulator);
-      };
+        return func(collection, setter, getIteratee(iteratee, 2), accumulator)
+      }
     }
 
     /**
@@ -4873,27 +5016,25 @@
     function createAssigner(assigner) {
       return baseRest(function(object, sources) {
         var index = -1,
-            length = sources.length,
-            customizer = length > 1 ? sources[length - 1] : undefined,
-            guard = length > 2 ? sources[2] : undefined;
+          length = sources.length,
+          customizer = length > 1 ? sources[length - 1] : undefined,
+          guard = length > 2 ? sources[2] : undefined
 
-        customizer = (assigner.length > 3 && typeof customizer == 'function')
-          ? (length--, customizer)
-          : undefined;
+        customizer = assigner.length > 3 && typeof customizer == 'function' ? (length--, customizer) : undefined
 
         if (guard && isIterateeCall(sources[0], sources[1], guard)) {
-          customizer = length < 3 ? undefined : customizer;
-          length = 1;
+          customizer = length < 3 ? undefined : customizer
+          length = 1
         }
-        object = Object(object);
+        object = Object(object)
         while (++index < length) {
-          var source = sources[index];
+          var source = sources[index]
           if (source) {
-            assigner(object, source, index, customizer);
+            assigner(object, source, index, customizer)
           }
         }
-        return object;
-      });
+        return object
+      })
     }
 
     /**
@@ -4907,22 +5048,22 @@
     function createBaseEach(eachFunc, fromRight) {
       return function(collection, iteratee) {
         if (collection == null) {
-          return collection;
+          return collection
         }
         if (!isArrayLike(collection)) {
-          return eachFunc(collection, iteratee);
+          return eachFunc(collection, iteratee)
         }
         var length = collection.length,
-            index = fromRight ? length : -1,
-            iterable = Object(collection);
+          index = fromRight ? length : -1,
+          iterable = Object(collection)
 
-        while ((fromRight ? index-- : ++index < length)) {
+        while (fromRight ? index-- : ++index < length) {
           if (iteratee(iterable[index], index, iterable) === false) {
-            break;
+            break
           }
         }
-        return collection;
-      };
+        return collection
+      }
     }
 
     /**
@@ -4935,18 +5076,18 @@
     function createBaseFor(fromRight) {
       return function(object, iteratee, keysFunc) {
         var index = -1,
-            iterable = Object(object),
-            props = keysFunc(object),
-            length = props.length;
+          iterable = Object(object),
+          props = keysFunc(object),
+          length = props.length
 
         while (length--) {
-          var key = props[fromRight ? length : ++index];
+          var key = props[fromRight ? length : ++index]
           if (iteratee(iterable[key], key, iterable) === false) {
-            break;
+            break
           }
         }
-        return object;
-      };
+        return object
+      }
     }
 
     /**
@@ -4961,13 +5102,13 @@
      */
     function createBind(func, bitmask, thisArg) {
       var isBind = bitmask & WRAP_BIND_FLAG,
-          Ctor = createCtor(func);
+        Ctor = createCtor(func)
 
       function wrapper() {
-        var fn = (this && this !== root && this instanceof wrapper) ? Ctor : func;
-        return fn.apply(isBind ? thisArg : this, arguments);
+        var fn = this && this !== root && this instanceof wrapper ? Ctor : func
+        return fn.apply(isBind ? thisArg : this, arguments)
       }
-      return wrapper;
+      return wrapper
     }
 
     /**
@@ -4979,22 +5120,16 @@
      */
     function createCaseFirst(methodName) {
       return function(string) {
-        string = toString(string);
+        string = toString(string)
 
-        var strSymbols = hasUnicode(string)
-          ? stringToArray(string)
-          : undefined;
+        var strSymbols = hasUnicode(string) ? stringToArray(string) : undefined
 
-        var chr = strSymbols
-          ? strSymbols[0]
-          : string.charAt(0);
+        var chr = strSymbols ? strSymbols[0] : string.charAt(0)
 
-        var trailing = strSymbols
-          ? castSlice(strSymbols, 1).join('')
-          : string.slice(1);
+        var trailing = strSymbols ? castSlice(strSymbols, 1).join('') : string.slice(1)
 
-        return chr[methodName]() + trailing;
-      };
+        return chr[methodName]() + trailing
+      }
     }
 
     /**
@@ -5006,8 +5141,8 @@
      */
     function createCompounder(callback) {
       return function(string) {
-        return arrayReduce(words(deburr(string).replace(reApos, '')), callback, '');
-      };
+        return arrayReduce(words(deburr(string).replace(reApos, '')), callback, '')
+      }
     }
 
     /**
@@ -5023,24 +5158,32 @@
         // Use a `switch` statement to work with class constructors. See
         // http://ecma-international.org/ecma-262/7.0/#sec-ecmascript-function-objects-call-thisargument-argumentslist
         // for more details.
-        var args = arguments;
+        var args = arguments
         switch (args.length) {
-          case 0: return new Ctor;
-          case 1: return new Ctor(args[0]);
-          case 2: return new Ctor(args[0], args[1]);
-          case 3: return new Ctor(args[0], args[1], args[2]);
-          case 4: return new Ctor(args[0], args[1], args[2], args[3]);
-          case 5: return new Ctor(args[0], args[1], args[2], args[3], args[4]);
-          case 6: return new Ctor(args[0], args[1], args[2], args[3], args[4], args[5]);
-          case 7: return new Ctor(args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
+          case 0:
+            return new Ctor()
+          case 1:
+            return new Ctor(args[0])
+          case 2:
+            return new Ctor(args[0], args[1])
+          case 3:
+            return new Ctor(args[0], args[1], args[2])
+          case 4:
+            return new Ctor(args[0], args[1], args[2], args[3])
+          case 5:
+            return new Ctor(args[0], args[1], args[2], args[3], args[4])
+          case 6:
+            return new Ctor(args[0], args[1], args[2], args[3], args[4], args[5])
+          case 7:
+            return new Ctor(args[0], args[1], args[2], args[3], args[4], args[5], args[6])
         }
         var thisBinding = baseCreate(Ctor.prototype),
-            result = Ctor.apply(thisBinding, args);
+          result = Ctor.apply(thisBinding, args)
 
         // Mimic the constructor's `return` behavior.
         // See https://es5.github.io/#x13.2.2 for more details.
-        return isObject(result) ? result : thisBinding;
-      };
+        return isObject(result) ? result : thisBinding
+      }
     }
 
     /**
@@ -5053,31 +5196,41 @@
      * @returns {Function} Returns the new wrapped function.
      */
     function createCurry(func, bitmask, arity) {
-      var Ctor = createCtor(func);
+      var Ctor = createCtor(func)
 
       function wrapper() {
         var length = arguments.length,
-            args = Array(length),
-            index = length,
-            placeholder = getHolder(wrapper);
+          args = Array(length),
+          index = length,
+          placeholder = getHolder(wrapper)
 
         while (index--) {
-          args[index] = arguments[index];
+          args[index] = arguments[index]
         }
-        var holders = (length < 3 && args[0] !== placeholder && args[length - 1] !== placeholder)
-          ? []
-          : replaceHolders(args, placeholder);
+        var holders =
+          length < 3 && args[0] !== placeholder && args[length - 1] !== placeholder
+            ? []
+            : replaceHolders(args, placeholder)
 
-        length -= holders.length;
+        length -= holders.length
         if (length < arity) {
           return createRecurry(
-            func, bitmask, createHybrid, wrapper.placeholder, undefined,
-            args, holders, undefined, undefined, arity - length);
+            func,
+            bitmask,
+            createHybrid,
+            wrapper.placeholder,
+            undefined,
+            args,
+            holders,
+            undefined,
+            undefined,
+            arity - length
+          )
         }
-        var fn = (this && this !== root && this instanceof wrapper) ? Ctor : func;
-        return apply(fn, this, args);
+        var fn = this && this !== root && this instanceof wrapper ? Ctor : func
+        return apply(fn, this, args)
       }
-      return wrapper;
+      return wrapper
     }
 
     /**
@@ -5089,15 +5242,17 @@
      */
     function createFind(findIndexFunc) {
       return function(collection, predicate, fromIndex) {
-        var iterable = Object(collection);
+        var iterable = Object(collection)
         if (!isArrayLike(collection)) {
-          var iteratee = getIteratee(predicate, 3);
-          collection = keys(collection);
-          predicate = function(key) { return iteratee(iterable[key], key, iterable); };
+          var iteratee = getIteratee(predicate, 3)
+          collection = keys(collection)
+          predicate = function(key) {
+            return iteratee(iterable[key], key, iterable)
+          }
         }
-        var index = findIndexFunc(collection, predicate, fromIndex);
-        return index > -1 ? iterable[iteratee ? collection[index] : index] : undefined;
-      };
+        var index = findIndexFunc(collection, predicate, fromIndex)
+        return index > -1 ? iterable[iteratee ? collection[index] : index] : undefined
+      }
     }
 
     /**
@@ -5110,55 +5265,56 @@
     function createFlow(fromRight) {
       return flatRest(function(funcs) {
         var length = funcs.length,
-            index = length,
-            prereq = LodashWrapper.prototype.thru;
+          index = length,
+          prereq = LodashWrapper.prototype.thru
 
         if (fromRight) {
-          funcs.reverse();
+          funcs.reverse()
         }
         while (index--) {
-          var func = funcs[index];
+          var func = funcs[index]
           if (typeof func != 'function') {
-            throw new TypeError(FUNC_ERROR_TEXT);
+            throw new TypeError(FUNC_ERROR_TEXT)
           }
           if (prereq && !wrapper && getFuncName(func) == 'wrapper') {
-            var wrapper = new LodashWrapper([], true);
+            var wrapper = new LodashWrapper([], true)
           }
         }
-        index = wrapper ? index : length;
+        index = wrapper ? index : length
         while (++index < length) {
-          func = funcs[index];
+          func = funcs[index]
 
           var funcName = getFuncName(func),
-              data = funcName == 'wrapper' ? getData(func) : undefined;
+            data = funcName == 'wrapper' ? getData(func) : undefined
 
-          if (data && isLaziable(data[0]) &&
-                data[1] == (WRAP_ARY_FLAG | WRAP_CURRY_FLAG | WRAP_PARTIAL_FLAG | WRAP_REARG_FLAG) &&
-                !data[4].length && data[9] == 1
-              ) {
-            wrapper = wrapper[getFuncName(data[0])].apply(wrapper, data[3]);
+          if (
+            data &&
+            isLaziable(data[0]) &&
+            data[1] == (WRAP_ARY_FLAG | WRAP_CURRY_FLAG | WRAP_PARTIAL_FLAG | WRAP_REARG_FLAG) &&
+            !data[4].length &&
+            data[9] == 1
+          ) {
+            wrapper = wrapper[getFuncName(data[0])].apply(wrapper, data[3])
           } else {
-            wrapper = (func.length == 1 && isLaziable(func))
-              ? wrapper[funcName]()
-              : wrapper.thru(func);
+            wrapper = func.length == 1 && isLaziable(func) ? wrapper[funcName]() : wrapper.thru(func)
           }
         }
         return function() {
           var args = arguments,
-              value = args[0];
+            value = args[0]
 
           if (wrapper && args.length == 1 && isArray(value)) {
-            return wrapper.plant(value).value();
+            return wrapper.plant(value).value()
           }
           var index = 0,
-              result = length ? funcs[index].apply(this, args) : value;
+            result = length ? funcs[index].apply(this, args) : value
 
           while (++index < length) {
-            result = funcs[index].call(this, result);
+            result = funcs[index].call(this, result)
           }
-          return result;
-        };
-      });
+          return result
+        }
+      })
     }
 
     /**
@@ -5182,56 +5338,64 @@
      */
     function createHybrid(func, bitmask, thisArg, partials, holders, partialsRight, holdersRight, argPos, ary, arity) {
       var isAry = bitmask & WRAP_ARY_FLAG,
-          isBind = bitmask & WRAP_BIND_FLAG,
-          isBindKey = bitmask & WRAP_BIND_KEY_FLAG,
-          isCurried = bitmask & (WRAP_CURRY_FLAG | WRAP_CURRY_RIGHT_FLAG),
-          isFlip = bitmask & WRAP_FLIP_FLAG,
-          Ctor = isBindKey ? undefined : createCtor(func);
+        isBind = bitmask & WRAP_BIND_FLAG,
+        isBindKey = bitmask & WRAP_BIND_KEY_FLAG,
+        isCurried = bitmask & (WRAP_CURRY_FLAG | WRAP_CURRY_RIGHT_FLAG),
+        isFlip = bitmask & WRAP_FLIP_FLAG,
+        Ctor = isBindKey ? undefined : createCtor(func)
 
       function wrapper() {
         var length = arguments.length,
-            args = Array(length),
-            index = length;
+          args = Array(length),
+          index = length
 
         while (index--) {
-          args[index] = arguments[index];
+          args[index] = arguments[index]
         }
         if (isCurried) {
           var placeholder = getHolder(wrapper),
-              holdersCount = countHolders(args, placeholder);
+            holdersCount = countHolders(args, placeholder)
         }
         if (partials) {
-          args = composeArgs(args, partials, holders, isCurried);
+          args = composeArgs(args, partials, holders, isCurried)
         }
         if (partialsRight) {
-          args = composeArgsRight(args, partialsRight, holdersRight, isCurried);
+          args = composeArgsRight(args, partialsRight, holdersRight, isCurried)
         }
-        length -= holdersCount;
+        length -= holdersCount
         if (isCurried && length < arity) {
-          var newHolders = replaceHolders(args, placeholder);
+          var newHolders = replaceHolders(args, placeholder)
           return createRecurry(
-            func, bitmask, createHybrid, wrapper.placeholder, thisArg,
-            args, newHolders, argPos, ary, arity - length
-          );
+            func,
+            bitmask,
+            createHybrid,
+            wrapper.placeholder,
+            thisArg,
+            args,
+            newHolders,
+            argPos,
+            ary,
+            arity - length
+          )
         }
         var thisBinding = isBind ? thisArg : this,
-            fn = isBindKey ? thisBinding[func] : func;
+          fn = isBindKey ? thisBinding[func] : func
 
-        length = args.length;
+        length = args.length
         if (argPos) {
-          args = reorder(args, argPos);
+          args = reorder(args, argPos)
         } else if (isFlip && length > 1) {
-          args.reverse();
+          args.reverse()
         }
         if (isAry && ary < length) {
-          args.length = ary;
+          args.length = ary
         }
         if (this && this !== root && this instanceof wrapper) {
-          fn = Ctor || createCtor(fn);
+          fn = Ctor || createCtor(fn)
         }
-        return fn.apply(thisBinding, args);
+        return fn.apply(thisBinding, args)
       }
-      return wrapper;
+      return wrapper
     }
 
     /**
@@ -5244,8 +5408,8 @@
      */
     function createInverter(setter, toIteratee) {
       return function(object, iteratee) {
-        return baseInverter(object, setter, toIteratee(iteratee), {});
-      };
+        return baseInverter(object, setter, toIteratee(iteratee), {})
+      }
     }
 
     /**
@@ -5258,28 +5422,28 @@
      */
     function createMathOperation(operator, defaultValue) {
       return function(value, other) {
-        var result;
+        var result
         if (value === undefined && other === undefined) {
-          return defaultValue;
+          return defaultValue
         }
         if (value !== undefined) {
-          result = value;
+          result = value
         }
         if (other !== undefined) {
           if (result === undefined) {
-            return other;
+            return other
           }
           if (typeof value == 'string' || typeof other == 'string') {
-            value = baseToString(value);
-            other = baseToString(other);
+            value = baseToString(value)
+            other = baseToString(other)
           } else {
-            value = baseToNumber(value);
-            other = baseToNumber(other);
+            value = baseToNumber(value)
+            other = baseToNumber(other)
           }
-          result = operator(value, other);
+          result = operator(value, other)
         }
-        return result;
-      };
+        return result
+      }
     }
 
     /**
@@ -5291,14 +5455,14 @@
      */
     function createOver(arrayFunc) {
       return flatRest(function(iteratees) {
-        iteratees = arrayMap(iteratees, baseUnary(getIteratee()));
+        iteratees = arrayMap(iteratees, baseUnary(getIteratee()))
         return baseRest(function(args) {
-          var thisArg = this;
+          var thisArg = this
           return arrayFunc(iteratees, function(iteratee) {
-            return apply(iteratee, thisArg, args);
-          });
-        });
-      });
+            return apply(iteratee, thisArg, args)
+          })
+        })
+      })
     }
 
     /**
@@ -5311,16 +5475,14 @@
      * @returns {string} Returns the padding for `string`.
      */
     function createPadding(length, chars) {
-      chars = chars === undefined ? ' ' : baseToString(chars);
+      chars = chars === undefined ? ' ' : baseToString(chars)
 
-      var charsLength = chars.length;
+      var charsLength = chars.length
       if (charsLength < 2) {
-        return charsLength ? baseRepeat(chars, length) : chars;
+        return charsLength ? baseRepeat(chars, length) : chars
       }
-      var result = baseRepeat(chars, nativeCeil(length / stringSize(chars)));
-      return hasUnicode(chars)
-        ? castSlice(stringToArray(result), 0, length).join('')
-        : result.slice(0, length);
+      var result = baseRepeat(chars, nativeCeil(length / stringSize(chars)))
+      return hasUnicode(chars) ? castSlice(stringToArray(result), 0, length).join('') : result.slice(0, length)
     }
 
     /**
@@ -5337,25 +5499,25 @@
      */
     function createPartial(func, bitmask, thisArg, partials) {
       var isBind = bitmask & WRAP_BIND_FLAG,
-          Ctor = createCtor(func);
+        Ctor = createCtor(func)
 
       function wrapper() {
         var argsIndex = -1,
-            argsLength = arguments.length,
-            leftIndex = -1,
-            leftLength = partials.length,
-            args = Array(leftLength + argsLength),
-            fn = (this && this !== root && this instanceof wrapper) ? Ctor : func;
+          argsLength = arguments.length,
+          leftIndex = -1,
+          leftLength = partials.length,
+          args = Array(leftLength + argsLength),
+          fn = this && this !== root && this instanceof wrapper ? Ctor : func
 
         while (++leftIndex < leftLength) {
-          args[leftIndex] = partials[leftIndex];
+          args[leftIndex] = partials[leftIndex]
         }
         while (argsLength--) {
-          args[leftIndex++] = arguments[++argsIndex];
+          args[leftIndex++] = arguments[++argsIndex]
         }
-        return apply(fn, isBind ? thisArg : this, args);
+        return apply(fn, isBind ? thisArg : this, args)
       }
-      return wrapper;
+      return wrapper
     }
 
     /**
@@ -5368,19 +5530,19 @@
     function createRange(fromRight) {
       return function(start, end, step) {
         if (step && typeof step != 'number' && isIterateeCall(start, end, step)) {
-          end = step = undefined;
+          end = step = undefined
         }
         // Ensure the sign of `-0` is preserved.
-        start = toFinite(start);
+        start = toFinite(start)
         if (end === undefined) {
-          end = start;
-          start = 0;
+          end = start
+          start = 0
         } else {
-          end = toFinite(end);
+          end = toFinite(end)
         }
-        step = step === undefined ? (start < end ? 1 : -1) : toFinite(step);
-        return baseRange(start, end, step, fromRight);
-      };
+        step = step === undefined ? (start < end ? 1 : -1) : toFinite(step)
+        return baseRange(start, end, step, fromRight)
+      }
     }
 
     /**
@@ -5393,11 +5555,11 @@
     function createRelationalOperation(operator) {
       return function(value, other) {
         if (!(typeof value == 'string' && typeof other == 'string')) {
-          value = toNumber(value);
-          other = toNumber(other);
+          value = toNumber(value)
+          other = toNumber(other)
         }
-        return operator(value, other);
-      };
+        return operator(value, other)
+      }
     }
 
     /**
@@ -5419,28 +5581,36 @@
      */
     function createRecurry(func, bitmask, wrapFunc, placeholder, thisArg, partials, holders, argPos, ary, arity) {
       var isCurry = bitmask & WRAP_CURRY_FLAG,
-          newHolders = isCurry ? holders : undefined,
-          newHoldersRight = isCurry ? undefined : holders,
-          newPartials = isCurry ? partials : undefined,
-          newPartialsRight = isCurry ? undefined : partials;
+        newHolders = isCurry ? holders : undefined,
+        newHoldersRight = isCurry ? undefined : holders,
+        newPartials = isCurry ? partials : undefined,
+        newPartialsRight = isCurry ? undefined : partials
 
-      bitmask |= (isCurry ? WRAP_PARTIAL_FLAG : WRAP_PARTIAL_RIGHT_FLAG);
-      bitmask &= ~(isCurry ? WRAP_PARTIAL_RIGHT_FLAG : WRAP_PARTIAL_FLAG);
+      bitmask |= isCurry ? WRAP_PARTIAL_FLAG : WRAP_PARTIAL_RIGHT_FLAG
+      bitmask &= ~(isCurry ? WRAP_PARTIAL_RIGHT_FLAG : WRAP_PARTIAL_FLAG)
 
       if (!(bitmask & WRAP_CURRY_BOUND_FLAG)) {
-        bitmask &= ~(WRAP_BIND_FLAG | WRAP_BIND_KEY_FLAG);
+        bitmask &= ~(WRAP_BIND_FLAG | WRAP_BIND_KEY_FLAG)
       }
       var newData = [
-        func, bitmask, thisArg, newPartials, newHolders, newPartialsRight,
-        newHoldersRight, argPos, ary, arity
-      ];
+        func,
+        bitmask,
+        thisArg,
+        newPartials,
+        newHolders,
+        newPartialsRight,
+        newHoldersRight,
+        argPos,
+        ary,
+        arity
+      ]
 
-      var result = wrapFunc.apply(undefined, newData);
+      var result = wrapFunc.apply(undefined, newData)
       if (isLaziable(func)) {
-        setData(result, newData);
+        setData(result, newData)
       }
-      result.placeholder = placeholder;
-      return setWrapToString(result, func, bitmask);
+      result.placeholder = placeholder
+      return setWrapToString(result, func, bitmask)
     }
 
     /**
@@ -5451,21 +5621,21 @@
      * @returns {Function} Returns the new round function.
      */
     function createRound(methodName) {
-      var func = Math[methodName];
+      var func = Math[methodName]
       return function(number, precision) {
-        number = toNumber(number);
-        precision = precision == null ? 0 : nativeMin(toInteger(precision), 292);
+        number = toNumber(number)
+        precision = precision == null ? 0 : nativeMin(toInteger(precision), 292)
         if (precision) {
           // Shift with exponential notation to avoid floating-point issues.
           // See [MDN](https://mdn.io/round#Examples) for more details.
           var pair = (toString(number) + 'e').split('e'),
-              value = func(pair[0] + 'e' + (+pair[1] + precision));
+            value = func(pair[0] + 'e' + (+pair[1] + precision))
 
-          pair = (toString(value) + 'e').split('e');
-          return +(pair[0] + 'e' + (+pair[1] - precision));
+          pair = (toString(value) + 'e').split('e')
+          return +(pair[0] + 'e' + (+pair[1] - precision))
         }
-        return func(number);
-      };
+        return func(number)
+      }
     }
 
     /**
@@ -5475,9 +5645,11 @@
      * @param {Array} values The values to add to the set.
      * @returns {Object} Returns the new set.
      */
-    var createSet = !(Set && (1 / setToArray(new Set([,-0]))[1]) == INFINITY) ? noop : function(values) {
-      return new Set(values);
-    };
+    var createSet = !(Set && 1 / setToArray(new Set([, -0]))[1] == INFINITY)
+      ? noop
+      : function(values) {
+          return new Set(values)
+        }
 
     /**
      * Creates a `_.toPairs` or `_.toPairsIn` function.
@@ -5488,15 +5660,15 @@
      */
     function createToPairs(keysFunc) {
       return function(object) {
-        var tag = getTag(object);
+        var tag = getTag(object)
         if (tag == mapTag) {
-          return mapToArray(object);
+          return mapToArray(object)
         }
         if (tag == setTag) {
-          return setToPairs(object);
+          return setToPairs(object)
         }
-        return baseToPairs(object, keysFunc(object));
-      };
+        return baseToPairs(object, keysFunc(object))
+      }
     }
 
     /**
@@ -5525,58 +5697,53 @@
      * @returns {Function} Returns the new wrapped function.
      */
     function createWrap(func, bitmask, thisArg, partials, holders, argPos, ary, arity) {
-      var isBindKey = bitmask & WRAP_BIND_KEY_FLAG;
+      var isBindKey = bitmask & WRAP_BIND_KEY_FLAG
       if (!isBindKey && typeof func != 'function') {
-        throw new TypeError(FUNC_ERROR_TEXT);
+        throw new TypeError(FUNC_ERROR_TEXT)
       }
-      var length = partials ? partials.length : 0;
+      var length = partials ? partials.length : 0
       if (!length) {
-        bitmask &= ~(WRAP_PARTIAL_FLAG | WRAP_PARTIAL_RIGHT_FLAG);
-        partials = holders = undefined;
+        bitmask &= ~(WRAP_PARTIAL_FLAG | WRAP_PARTIAL_RIGHT_FLAG)
+        partials = holders = undefined
       }
-      ary = ary === undefined ? ary : nativeMax(toInteger(ary), 0);
-      arity = arity === undefined ? arity : toInteger(arity);
-      length -= holders ? holders.length : 0;
+      ary = ary === undefined ? ary : nativeMax(toInteger(ary), 0)
+      arity = arity === undefined ? arity : toInteger(arity)
+      length -= holders ? holders.length : 0
 
       if (bitmask & WRAP_PARTIAL_RIGHT_FLAG) {
         var partialsRight = partials,
-            holdersRight = holders;
+          holdersRight = holders
 
-        partials = holders = undefined;
+        partials = holders = undefined
       }
-      var data = isBindKey ? undefined : getData(func);
+      var data = isBindKey ? undefined : getData(func)
 
-      var newData = [
-        func, bitmask, thisArg, partials, holders, partialsRight, holdersRight,
-        argPos, ary, arity
-      ];
+      var newData = [func, bitmask, thisArg, partials, holders, partialsRight, holdersRight, argPos, ary, arity]
 
       if (data) {
-        mergeData(newData, data);
+        mergeData(newData, data)
       }
-      func = newData[0];
-      bitmask = newData[1];
-      thisArg = newData[2];
-      partials = newData[3];
-      holders = newData[4];
-      arity = newData[9] = newData[9] === undefined
-        ? (isBindKey ? 0 : func.length)
-        : nativeMax(newData[9] - length, 0);
+      func = newData[0]
+      bitmask = newData[1]
+      thisArg = newData[2]
+      partials = newData[3]
+      holders = newData[4]
+      arity = newData[9] = newData[9] === undefined ? (isBindKey ? 0 : func.length) : nativeMax(newData[9] - length, 0)
 
       if (!arity && bitmask & (WRAP_CURRY_FLAG | WRAP_CURRY_RIGHT_FLAG)) {
-        bitmask &= ~(WRAP_CURRY_FLAG | WRAP_CURRY_RIGHT_FLAG);
+        bitmask &= ~(WRAP_CURRY_FLAG | WRAP_CURRY_RIGHT_FLAG)
       }
       if (!bitmask || bitmask == WRAP_BIND_FLAG) {
-        var result = createBind(func, bitmask, thisArg);
+        var result = createBind(func, bitmask, thisArg)
       } else if (bitmask == WRAP_CURRY_FLAG || bitmask == WRAP_CURRY_RIGHT_FLAG) {
-        result = createCurry(func, bitmask, arity);
+        result = createCurry(func, bitmask, arity)
       } else if ((bitmask == WRAP_PARTIAL_FLAG || bitmask == (WRAP_BIND_FLAG | WRAP_PARTIAL_FLAG)) && !holders.length) {
-        result = createPartial(func, bitmask, thisArg, partials);
+        result = createPartial(func, bitmask, thisArg, partials)
       } else {
-        result = createHybrid.apply(undefined, newData);
+        result = createHybrid.apply(undefined, newData)
       }
-      var setter = data ? baseSetData : setData;
-      return setWrapToString(setter(result, newData), func, bitmask);
+      var setter = data ? baseSetData : setData
+      return setWrapToString(setter(result, newData), func, bitmask)
     }
 
     /**
@@ -5592,11 +5759,10 @@
      * @returns {*} Returns the value to assign.
      */
     function customDefaultsAssignIn(objValue, srcValue, key, object) {
-      if (objValue === undefined ||
-          (eq(objValue, objectProto[key]) && !hasOwnProperty.call(object, key))) {
-        return srcValue;
+      if (objValue === undefined || (eq(objValue, objectProto[key]) && !hasOwnProperty.call(object, key))) {
+        return srcValue
       }
-      return objValue;
+      return objValue
     }
 
     /**
@@ -5616,11 +5782,11 @@
     function customDefaultsMerge(objValue, srcValue, key, object, source, stack) {
       if (isObject(objValue) && isObject(srcValue)) {
         // Recursively merge objects and arrays (susceptible to call stack limits).
-        stack.set(srcValue, objValue);
-        baseMerge(objValue, srcValue, undefined, customDefaultsMerge, stack);
-        stack['delete'](srcValue);
+        stack.set(srcValue, objValue)
+        baseMerge(objValue, srcValue, undefined, customDefaultsMerge, stack)
+        stack['delete'](srcValue)
       }
-      return objValue;
+      return objValue
     }
 
     /**
@@ -5633,7 +5799,7 @@
      * @returns {*} Returns the uncloned value or `undefined` to defer cloning to `_.cloneDeep`.
      */
     function customOmitClone(value) {
-      return isPlainObject(value) ? undefined : value;
+      return isPlainObject(value) ? undefined : value
     }
 
     /**
@@ -5651,63 +5817,64 @@
      */
     function equalArrays(array, other, bitmask, customizer, equalFunc, stack) {
       var isPartial = bitmask & COMPARE_PARTIAL_FLAG,
-          arrLength = array.length,
-          othLength = other.length;
+        arrLength = array.length,
+        othLength = other.length
 
       if (arrLength != othLength && !(isPartial && othLength > arrLength)) {
-        return false;
+        return false
       }
       // Assume cyclic values are equal.
-      var stacked = stack.get(array);
+      var stacked = stack.get(array)
       if (stacked && stack.get(other)) {
-        return stacked == other;
+        return stacked == other
       }
       var index = -1,
-          result = true,
-          seen = (bitmask & COMPARE_UNORDERED_FLAG) ? new SetCache : undefined;
+        result = true,
+        seen = bitmask & COMPARE_UNORDERED_FLAG ? new SetCache() : undefined
 
-      stack.set(array, other);
-      stack.set(other, array);
+      stack.set(array, other)
+      stack.set(other, array)
 
       // Ignore non-index properties.
       while (++index < arrLength) {
         var arrValue = array[index],
-            othValue = other[index];
+          othValue = other[index]
 
         if (customizer) {
           var compared = isPartial
             ? customizer(othValue, arrValue, index, other, array, stack)
-            : customizer(arrValue, othValue, index, array, other, stack);
+            : customizer(arrValue, othValue, index, array, other, stack)
         }
         if (compared !== undefined) {
           if (compared) {
-            continue;
+            continue
           }
-          result = false;
-          break;
+          result = false
+          break
         }
         // Recursively compare arrays (susceptible to call stack limits).
         if (seen) {
-          if (!arraySome(other, function(othValue, othIndex) {
-                if (!cacheHas(seen, othIndex) &&
-                    (arrValue === othValue || equalFunc(arrValue, othValue, bitmask, customizer, stack))) {
-                  return seen.push(othIndex);
-                }
-              })) {
-            result = false;
-            break;
+          if (
+            !arraySome(other, function(othValue, othIndex) {
+              if (
+                !cacheHas(seen, othIndex) &&
+                (arrValue === othValue || equalFunc(arrValue, othValue, bitmask, customizer, stack))
+              ) {
+                return seen.push(othIndex)
+              }
+            })
+          ) {
+            result = false
+            break
           }
-        } else if (!(
-              arrValue === othValue ||
-                equalFunc(arrValue, othValue, bitmask, customizer, stack)
-            )) {
-          result = false;
-          break;
+        } else if (!(arrValue === othValue || equalFunc(arrValue, othValue, bitmask, customizer, stack))) {
+          result = false
+          break
         }
       }
-      stack['delete'](array);
-      stack['delete'](other);
-      return result;
+      stack['delete'](array)
+      stack['delete'](other)
+      return result
     }
 
     /**
@@ -5730,66 +5897,64 @@
     function equalByTag(object, other, tag, bitmask, customizer, equalFunc, stack) {
       switch (tag) {
         case dataViewTag:
-          if ((object.byteLength != other.byteLength) ||
-              (object.byteOffset != other.byteOffset)) {
-            return false;
+          if (object.byteLength != other.byteLength || object.byteOffset != other.byteOffset) {
+            return false
           }
-          object = object.buffer;
-          other = other.buffer;
+          object = object.buffer
+          other = other.buffer
 
         case arrayBufferTag:
-          if ((object.byteLength != other.byteLength) ||
-              !equalFunc(new Uint8Array(object), new Uint8Array(other))) {
-            return false;
+          if (object.byteLength != other.byteLength || !equalFunc(new Uint8Array(object), new Uint8Array(other))) {
+            return false
           }
-          return true;
+          return true
 
         case boolTag:
         case dateTag:
         case numberTag:
           // Coerce booleans to `1` or `0` and dates to milliseconds.
           // Invalid dates are coerced to `NaN`.
-          return eq(+object, +other);
+          return eq(+object, +other)
 
         case errorTag:
-          return object.name == other.name && object.message == other.message;
+          return object.name == other.name && object.message == other.message
 
         case regexpTag:
         case stringTag:
           // Coerce regexes to strings and treat strings, primitives and objects,
           // as equal. See http://www.ecma-international.org/ecma-262/7.0/#sec-regexp.prototype.tostring
           // for more details.
-          return object == (other + '');
+          return object == other + ''
 
         case mapTag:
-          var convert = mapToArray;
+          var convert = mapToArray
 
         case setTag:
-          var isPartial = bitmask & COMPARE_PARTIAL_FLAG;
-          convert || (convert = setToArray);
+          var isPartial = bitmask & COMPARE_PARTIAL_FLAG
+          convert || (convert = setToArray)
 
           if (object.size != other.size && !isPartial) {
-            return false;
+            return false
           }
           // Assume cyclic values are equal.
-          var stacked = stack.get(object);
+          var stacked = stack.get(object)
           if (stacked) {
-            return stacked == other;
+            return stacked == other
           }
-          bitmask |= COMPARE_UNORDERED_FLAG;
+          bitmask |= COMPARE_UNORDERED_FLAG
 
           // Recursively compare objects (susceptible to call stack limits).
-          stack.set(object, other);
-          var result = equalArrays(convert(object), convert(other), bitmask, customizer, equalFunc, stack);
-          stack['delete'](object);
-          return result;
+          stack.set(object, other)
+          var result = equalArrays(convert(object), convert(other), bitmask, customizer, equalFunc, stack)
+          stack['delete'](object)
+          return result
 
         case symbolTag:
           if (symbolValueOf) {
-            return symbolValueOf.call(object) == symbolValueOf.call(other);
+            return symbolValueOf.call(object) == symbolValueOf.call(other)
           }
       }
-      return false;
+      return false
     }
 
     /**
@@ -5807,66 +5972,73 @@
      */
     function equalObjects(object, other, bitmask, customizer, equalFunc, stack) {
       var isPartial = bitmask & COMPARE_PARTIAL_FLAG,
-          objProps = getAllKeys(object),
-          objLength = objProps.length,
-          othProps = getAllKeys(other),
-          othLength = othProps.length;
+        objProps = getAllKeys(object),
+        objLength = objProps.length,
+        othProps = getAllKeys(other),
+        othLength = othProps.length
 
       if (objLength != othLength && !isPartial) {
-        return false;
+        return false
       }
-      var index = objLength;
+      var index = objLength
       while (index--) {
-        var key = objProps[index];
+        var key = objProps[index]
         if (!(isPartial ? key in other : hasOwnProperty.call(other, key))) {
-          return false;
+          return false
         }
       }
       // Assume cyclic values are equal.
-      var stacked = stack.get(object);
+      var stacked = stack.get(object)
       if (stacked && stack.get(other)) {
-        return stacked == other;
+        return stacked == other
       }
-      var result = true;
-      stack.set(object, other);
-      stack.set(other, object);
+      var result = true
+      stack.set(object, other)
+      stack.set(other, object)
 
-      var skipCtor = isPartial;
+      var skipCtor = isPartial
       while (++index < objLength) {
-        key = objProps[index];
+        key = objProps[index]
         var objValue = object[key],
-            othValue = other[key];
+          othValue = other[key]
 
         if (customizer) {
           var compared = isPartial
             ? customizer(othValue, objValue, key, other, object, stack)
-            : customizer(objValue, othValue, key, object, other, stack);
+            : customizer(objValue, othValue, key, object, other, stack)
         }
         // Recursively compare objects (susceptible to call stack limits).
-        if (!(compared === undefined
-              ? (objValue === othValue || equalFunc(objValue, othValue, bitmask, customizer, stack))
-              : compared
-            )) {
-          result = false;
-          break;
+        if (
+          !(compared === undefined
+            ? objValue === othValue || equalFunc(objValue, othValue, bitmask, customizer, stack)
+            : compared)
+        ) {
+          result = false
+          break
         }
-        skipCtor || (skipCtor = key == 'constructor');
+        skipCtor || (skipCtor = key == 'constructor')
       }
       if (result && !skipCtor) {
         var objCtor = object.constructor,
-            othCtor = other.constructor;
+          othCtor = other.constructor
 
         // Non `Object` object instances with different constructors are not equal.
-        if (objCtor != othCtor &&
-            ('constructor' in object && 'constructor' in other) &&
-            !(typeof objCtor == 'function' && objCtor instanceof objCtor &&
-              typeof othCtor == 'function' && othCtor instanceof othCtor)) {
-          result = false;
+        if (
+          objCtor != othCtor &&
+          ('constructor' in object && 'constructor' in other) &&
+          !(
+            typeof objCtor == 'function' &&
+            objCtor instanceof objCtor &&
+            typeof othCtor == 'function' &&
+            othCtor instanceof othCtor
+          )
+        ) {
+          result = false
         }
       }
-      stack['delete'](object);
-      stack['delete'](other);
-      return result;
+      stack['delete'](object)
+      stack['delete'](other)
+      return result
     }
 
     /**
@@ -5877,7 +6049,7 @@
      * @returns {Function} Returns the new function.
      */
     function flatRest(func) {
-      return setToString(overRest(func, undefined, flatten), func + '');
+      return setToString(overRest(func, undefined, flatten), func + '')
     }
 
     /**
@@ -5888,7 +6060,7 @@
      * @returns {Array} Returns the array of property names and symbols.
      */
     function getAllKeys(object) {
-      return baseGetAllKeys(object, keys, getSymbols);
+      return baseGetAllKeys(object, keys, getSymbols)
     }
 
     /**
@@ -5900,7 +6072,7 @@
      * @returns {Array} Returns the array of property names and symbols.
      */
     function getAllKeysIn(object) {
-      return baseGetAllKeys(object, keysIn, getSymbolsIn);
+      return baseGetAllKeys(object, keysIn, getSymbolsIn)
     }
 
     /**
@@ -5910,9 +6082,11 @@
      * @param {Function} func The function to query.
      * @returns {*} Returns the metadata for `func`.
      */
-    var getData = !metaMap ? noop : function(func) {
-      return metaMap.get(func);
-    };
+    var getData = !metaMap
+      ? noop
+      : function(func) {
+          return metaMap.get(func)
+        }
 
     /**
      * Gets the name of `func`.
@@ -5922,18 +6096,18 @@
      * @returns {string} Returns the function name.
      */
     function getFuncName(func) {
-      var result = (func.name + ''),
-          array = realNames[result],
-          length = hasOwnProperty.call(realNames, result) ? array.length : 0;
+      var result = func.name + '',
+        array = realNames[result],
+        length = hasOwnProperty.call(realNames, result) ? array.length : 0
 
       while (length--) {
         var data = array[length],
-            otherFunc = data.func;
+          otherFunc = data.func
         if (otherFunc == null || otherFunc == func) {
-          return data.name;
+          return data.name
         }
       }
-      return result;
+      return result
     }
 
     /**
@@ -5944,8 +6118,8 @@
      * @returns {*} Returns the placeholder value.
      */
     function getHolder(func) {
-      var object = hasOwnProperty.call(lodash, 'placeholder') ? lodash : func;
-      return object.placeholder;
+      var object = hasOwnProperty.call(lodash, 'placeholder') ? lodash : func
+      return object.placeholder
     }
 
     /**
@@ -5960,9 +6134,9 @@
      * @returns {Function} Returns the chosen function or its result.
      */
     function getIteratee() {
-      var result = lodash.iteratee || iteratee;
-      result = result === iteratee ? baseIteratee : result;
-      return arguments.length ? result(arguments[0], arguments[1]) : result;
+      var result = lodash.iteratee || iteratee
+      result = result === iteratee ? baseIteratee : result
+      return arguments.length ? result(arguments[0], arguments[1]) : result
     }
 
     /**
@@ -5974,10 +6148,8 @@
      * @returns {*} Returns the map data.
      */
     function getMapData(map, key) {
-      var data = map.__data__;
-      return isKeyable(key)
-        ? data[typeof key == 'string' ? 'string' : 'hash']
-        : data.map;
+      var data = map.__data__
+      return isKeyable(key) ? data[typeof key == 'string' ? 'string' : 'hash'] : data.map
     }
 
     /**
@@ -5989,15 +6161,15 @@
      */
     function getMatchData(object) {
       var result = keys(object),
-          length = result.length;
+        length = result.length
 
       while (length--) {
         var key = result[length],
-            value = object[key];
+          value = object[key]
 
-        result[length] = [key, value, isStrictComparable(value)];
+        result[length] = [key, value, isStrictComparable(value)]
       }
-      return result;
+      return result
     }
 
     /**
@@ -6009,8 +6181,8 @@
      * @returns {*} Returns the function if it's native, else `undefined`.
      */
     function getNative(object, key) {
-      var value = getValue(object, key);
-      return baseIsNative(value) ? value : undefined;
+      var value = getValue(object, key)
+      return baseIsNative(value) ? value : undefined
     }
 
     /**
@@ -6022,22 +6194,22 @@
      */
     function getRawTag(value) {
       var isOwn = hasOwnProperty.call(value, symToStringTag),
-          tag = value[symToStringTag];
+        tag = value[symToStringTag]
 
       try {
-        value[symToStringTag] = undefined;
-        var unmasked = true;
+        value[symToStringTag] = undefined
+        var unmasked = true
       } catch (e) {}
 
-      var result = nativeObjectToString.call(value);
+      var result = nativeObjectToString.call(value)
       if (unmasked) {
         if (isOwn) {
-          value[symToStringTag] = tag;
+          value[symToStringTag] = tag
         } else {
-          delete value[symToStringTag];
+          delete value[symToStringTag]
         }
       }
-      return result;
+      return result
     }
 
     /**
@@ -6047,15 +6219,17 @@
      * @param {Object} object The object to query.
      * @returns {Array} Returns the array of symbols.
      */
-    var getSymbols = !nativeGetSymbols ? stubArray : function(object) {
-      if (object == null) {
-        return [];
-      }
-      object = Object(object);
-      return arrayFilter(nativeGetSymbols(object), function(symbol) {
-        return propertyIsEnumerable.call(object, symbol);
-      });
-    };
+    var getSymbols = !nativeGetSymbols
+      ? stubArray
+      : function(object) {
+          if (object == null) {
+            return []
+          }
+          object = Object(object)
+          return arrayFilter(nativeGetSymbols(object), function(symbol) {
+            return propertyIsEnumerable.call(object, symbol)
+          })
+        }
 
     /**
      * Creates an array of the own and inherited enumerable symbols of `object`.
@@ -6064,14 +6238,16 @@
      * @param {Object} object The object to query.
      * @returns {Array} Returns the array of symbols.
      */
-    var getSymbolsIn = !nativeGetSymbols ? stubArray : function(object) {
-      var result = [];
-      while (object) {
-        arrayPush(result, getSymbols(object));
-        object = getPrototype(object);
-      }
-      return result;
-    };
+    var getSymbolsIn = !nativeGetSymbols
+      ? stubArray
+      : function(object) {
+          var result = []
+          while (object) {
+            arrayPush(result, getSymbols(object))
+            object = getPrototype(object)
+          }
+          return result
+        }
 
     /**
      * Gets the `toStringTag` of `value`.
@@ -6080,30 +6256,37 @@
      * @param {*} value The value to query.
      * @returns {string} Returns the `toStringTag`.
      */
-    var getTag = baseGetTag;
+    var getTag = baseGetTag
 
     // Fallback for data views, maps, sets, and weak maps in IE 11 and promises in Node.js < 6.
-    if ((DataView && getTag(new DataView(new ArrayBuffer(1))) != dataViewTag) ||
-        (Map && getTag(new Map) != mapTag) ||
-        (Promise && getTag(Promise.resolve()) != promiseTag) ||
-        (Set && getTag(new Set) != setTag) ||
-        (WeakMap && getTag(new WeakMap) != weakMapTag)) {
+    if (
+      (DataView && getTag(new DataView(new ArrayBuffer(1))) != dataViewTag) ||
+      (Map && getTag(new Map()) != mapTag) ||
+      (Promise && getTag(Promise.resolve()) != promiseTag) ||
+      (Set && getTag(new Set()) != setTag) ||
+      (WeakMap && getTag(new WeakMap()) != weakMapTag)
+    ) {
       getTag = function(value) {
         var result = baseGetTag(value),
-            Ctor = result == objectTag ? value.constructor : undefined,
-            ctorString = Ctor ? toSource(Ctor) : '';
+          Ctor = result == objectTag ? value.constructor : undefined,
+          ctorString = Ctor ? toSource(Ctor) : ''
 
         if (ctorString) {
           switch (ctorString) {
-            case dataViewCtorString: return dataViewTag;
-            case mapCtorString: return mapTag;
-            case promiseCtorString: return promiseTag;
-            case setCtorString: return setTag;
-            case weakMapCtorString: return weakMapTag;
+            case dataViewCtorString:
+              return dataViewTag
+            case mapCtorString:
+              return mapTag
+            case promiseCtorString:
+              return promiseTag
+            case setCtorString:
+              return setTag
+            case weakMapCtorString:
+              return weakMapTag
           }
         }
-        return result;
-      };
+        return result
+      }
     }
 
     /**
@@ -6118,20 +6301,28 @@
      */
     function getView(start, end, transforms) {
       var index = -1,
-          length = transforms.length;
+        length = transforms.length
 
       while (++index < length) {
         var data = transforms[index],
-            size = data.size;
+          size = data.size
 
         switch (data.type) {
-          case 'drop':      start += size; break;
-          case 'dropRight': end -= size; break;
-          case 'take':      end = nativeMin(end, start + size); break;
-          case 'takeRight': start = nativeMax(start, end - size); break;
+          case 'drop':
+            start += size
+            break
+          case 'dropRight':
+            end -= size
+            break
+          case 'take':
+            end = nativeMin(end, start + size)
+            break
+          case 'takeRight':
+            start = nativeMax(start, end - size)
+            break
         }
       }
-      return { 'start': start, 'end': end };
+      return {start: start, end: end}
     }
 
     /**
@@ -6142,8 +6333,8 @@
      * @returns {Array} Returns the wrapper details.
      */
     function getWrapDetails(source) {
-      var match = source.match(reWrapDetails);
-      return match ? match[1].split(reSplitDetails) : [];
+      var match = source.match(reWrapDetails)
+      return match ? match[1].split(reSplitDetails) : []
     }
 
     /**
@@ -6156,25 +6347,24 @@
      * @returns {boolean} Returns `true` if `path` exists, else `false`.
      */
     function hasPath(object, path, hasFunc) {
-      path = castPath(path, object);
+      path = castPath(path, object)
 
       var index = -1,
-          length = path.length,
-          result = false;
+        length = path.length,
+        result = false
 
       while (++index < length) {
-        var key = toKey(path[index]);
+        var key = toKey(path[index])
         if (!(result = object != null && hasFunc(object, key))) {
-          break;
+          break
         }
-        object = object[key];
+        object = object[key]
       }
       if (result || ++index != length) {
-        return result;
+        return result
       }
-      length = object == null ? 0 : object.length;
-      return !!length && isLength(length) && isIndex(key, length) &&
-        (isArray(object) || isArguments(object));
+      length = object == null ? 0 : object.length
+      return !!length && isLength(length) && isIndex(key, length) && (isArray(object) || isArguments(object))
     }
 
     /**
@@ -6186,14 +6376,14 @@
      */
     function initCloneArray(array) {
       var length = array.length,
-          result = array.constructor(length);
+        result = array.constructor(length)
 
       // Add properties assigned by `RegExp#exec`.
       if (length && typeof array[0] == 'string' && hasOwnProperty.call(array, 'index')) {
-        result.index = array.index;
-        result.input = array.input;
+        result.index = array.index
+        result.input = array.input
       }
-      return result;
+      return result
     }
 
     /**
@@ -6204,9 +6394,7 @@
      * @returns {Object} Returns the initialized clone.
      */
     function initCloneObject(object) {
-      return (typeof object.constructor == 'function' && !isPrototype(object))
-        ? baseCreate(getPrototype(object))
-        : {};
+      return typeof object.constructor == 'function' && !isPrototype(object) ? baseCreate(getPrototype(object)) : {}
     }
 
     /**
@@ -6223,38 +6411,44 @@
      * @returns {Object} Returns the initialized clone.
      */
     function initCloneByTag(object, tag, cloneFunc, isDeep) {
-      var Ctor = object.constructor;
+      var Ctor = object.constructor
       switch (tag) {
         case arrayBufferTag:
-          return cloneArrayBuffer(object);
+          return cloneArrayBuffer(object)
 
         case boolTag:
         case dateTag:
-          return new Ctor(+object);
+          return new Ctor(+object)
 
         case dataViewTag:
-          return cloneDataView(object, isDeep);
+          return cloneDataView(object, isDeep)
 
-        case float32Tag: case float64Tag:
-        case int8Tag: case int16Tag: case int32Tag:
-        case uint8Tag: case uint8ClampedTag: case uint16Tag: case uint32Tag:
-          return cloneTypedArray(object, isDeep);
+        case float32Tag:
+        case float64Tag:
+        case int8Tag:
+        case int16Tag:
+        case int32Tag:
+        case uint8Tag:
+        case uint8ClampedTag:
+        case uint16Tag:
+        case uint32Tag:
+          return cloneTypedArray(object, isDeep)
 
         case mapTag:
-          return cloneMap(object, isDeep, cloneFunc);
+          return cloneMap(object, isDeep, cloneFunc)
 
         case numberTag:
         case stringTag:
-          return new Ctor(object);
+          return new Ctor(object)
 
         case regexpTag:
-          return cloneRegExp(object);
+          return cloneRegExp(object)
 
         case setTag:
-          return cloneSet(object, isDeep, cloneFunc);
+          return cloneSet(object, isDeep, cloneFunc)
 
         case symbolTag:
-          return cloneSymbol(object);
+          return cloneSymbol(object)
       }
     }
 
@@ -6267,14 +6461,14 @@
      * @returns {string} Returns the modified source.
      */
     function insertWrapDetails(source, details) {
-      var length = details.length;
+      var length = details.length
       if (!length) {
-        return source;
+        return source
       }
-      var lastIndex = length - 1;
-      details[lastIndex] = (length > 1 ? '& ' : '') + details[lastIndex];
-      details = details.join(length > 2 ? ', ' : ' ');
-      return source.replace(reWrapComment, '{\n/* [wrapped with ' + details + '] */\n');
+      var lastIndex = length - 1
+      details[lastIndex] = (length > 1 ? '& ' : '') + details[lastIndex]
+      details = details.join(length > 2 ? ', ' : ' ')
+      return source.replace(reWrapComment, '{\n/* [wrapped with ' + details + '] */\n')
     }
 
     /**
@@ -6285,8 +6479,7 @@
      * @returns {boolean} Returns `true` if `value` is flattenable, else `false`.
      */
     function isFlattenable(value) {
-      return isArray(value) || isArguments(value) ||
-        !!(spreadableSymbol && value && value[spreadableSymbol]);
+      return isArray(value) || isArguments(value) || !!(spreadableSymbol && value && value[spreadableSymbol])
     }
 
     /**
@@ -6298,10 +6491,12 @@
      * @returns {boolean} Returns `true` if `value` is a valid index, else `false`.
      */
     function isIndex(value, length) {
-      length = length == null ? MAX_SAFE_INTEGER : length;
-      return !!length &&
+      length = length == null ? MAX_SAFE_INTEGER : length
+      return (
+        !!length &&
         (typeof value == 'number' || reIsUint.test(value)) &&
-        (value > -1 && value % 1 == 0 && value < length);
+        (value > -1 && value % 1 == 0 && value < length)
+      )
     }
 
     /**
@@ -6316,16 +6511,15 @@
      */
     function isIterateeCall(value, index, object) {
       if (!isObject(object)) {
-        return false;
+        return false
       }
-      var type = typeof index;
-      if (type == 'number'
-            ? (isArrayLike(object) && isIndex(index, object.length))
-            : (type == 'string' && index in object)
-          ) {
-        return eq(object[index], value);
+      var type = typeof index
+      if (
+        type == 'number' ? isArrayLike(object) && isIndex(index, object.length) : type == 'string' && index in object
+      ) {
+        return eq(object[index], value)
       }
-      return false;
+      return false
     }
 
     /**
@@ -6338,15 +6532,13 @@
      */
     function isKey(value, object) {
       if (isArray(value)) {
-        return false;
+        return false
       }
-      var type = typeof value;
-      if (type == 'number' || type == 'symbol' || type == 'boolean' ||
-          value == null || isSymbol(value)) {
-        return true;
+      var type = typeof value
+      if (type == 'number' || type == 'symbol' || type == 'boolean' || value == null || isSymbol(value)) {
+        return true
       }
-      return reIsPlainProp.test(value) || !reIsDeepProp.test(value) ||
-        (object != null && value in Object(object));
+      return reIsPlainProp.test(value) || !reIsDeepProp.test(value) || (object != null && value in Object(object))
     }
 
     /**
@@ -6357,10 +6549,10 @@
      * @returns {boolean} Returns `true` if `value` is suitable, else `false`.
      */
     function isKeyable(value) {
-      var type = typeof value;
-      return (type == 'string' || type == 'number' || type == 'symbol' || type == 'boolean')
-        ? (value !== '__proto__')
-        : (value === null);
+      var type = typeof value
+      return type == 'string' || type == 'number' || type == 'symbol' || type == 'boolean'
+        ? value !== '__proto__'
+        : value === null
     }
 
     /**
@@ -6373,16 +6565,16 @@
      */
     function isLaziable(func) {
       var funcName = getFuncName(func),
-          other = lodash[funcName];
+        other = lodash[funcName]
 
       if (typeof other != 'function' || !(funcName in LazyWrapper.prototype)) {
-        return false;
+        return false
       }
       if (func === other) {
-        return true;
+        return true
       }
-      var data = getData(other);
-      return !!data && func === data[0];
+      var data = getData(other)
+      return !!data && func === data[0]
     }
 
     /**
@@ -6393,7 +6585,7 @@
      * @returns {boolean} Returns `true` if `func` is masked, else `false`.
      */
     function isMasked(func) {
-      return !!maskSrcKey && (maskSrcKey in func);
+      return !!maskSrcKey && maskSrcKey in func
     }
 
     /**
@@ -6403,7 +6595,7 @@
      * @param {*} value The value to check.
      * @returns {boolean} Returns `true` if `func` is maskable, else `false`.
      */
-    var isMaskable = coreJsData ? isFunction : stubFalse;
+    var isMaskable = coreJsData ? isFunction : stubFalse
 
     /**
      * Checks if `value` is likely a prototype object.
@@ -6414,9 +6606,9 @@
      */
     function isPrototype(value) {
       var Ctor = value && value.constructor,
-          proto = (typeof Ctor == 'function' && Ctor.prototype) || objectProto;
+        proto = (typeof Ctor == 'function' && Ctor.prototype) || objectProto
 
-      return value === proto;
+      return value === proto
     }
 
     /**
@@ -6428,7 +6620,7 @@
      *  equality comparisons, else `false`.
      */
     function isStrictComparable(value) {
-      return value === value && !isObject(value);
+      return value === value && !isObject(value)
     }
 
     /**
@@ -6443,11 +6635,10 @@
     function matchesStrictComparable(key, srcValue) {
       return function(object) {
         if (object == null) {
-          return false;
+          return false
         }
-        return object[key] === srcValue &&
-          (srcValue !== undefined || (key in Object(object)));
-      };
+        return object[key] === srcValue && (srcValue !== undefined || key in Object(object))
+      }
     }
 
     /**
@@ -6461,13 +6652,13 @@
     function memoizeCapped(func) {
       var result = memoize(func, function(key) {
         if (cache.size === MAX_MEMOIZE_SIZE) {
-          cache.clear();
+          cache.clear()
         }
-        return key;
-      });
+        return key
+      })
 
-      var cache = result.cache;
-      return result;
+      var cache = result.cache
+      return result
     }
 
     /**
@@ -6488,57 +6679,57 @@
      */
     function mergeData(data, source) {
       var bitmask = data[1],
-          srcBitmask = source[1],
-          newBitmask = bitmask | srcBitmask,
-          isCommon = newBitmask < (WRAP_BIND_FLAG | WRAP_BIND_KEY_FLAG | WRAP_ARY_FLAG);
+        srcBitmask = source[1],
+        newBitmask = bitmask | srcBitmask,
+        isCommon = newBitmask < (WRAP_BIND_FLAG | WRAP_BIND_KEY_FLAG | WRAP_ARY_FLAG)
 
       var isCombo =
-        ((srcBitmask == WRAP_ARY_FLAG) && (bitmask == WRAP_CURRY_FLAG)) ||
-        ((srcBitmask == WRAP_ARY_FLAG) && (bitmask == WRAP_REARG_FLAG) && (data[7].length <= source[8])) ||
-        ((srcBitmask == (WRAP_ARY_FLAG | WRAP_REARG_FLAG)) && (source[7].length <= source[8]) && (bitmask == WRAP_CURRY_FLAG));
+        (srcBitmask == WRAP_ARY_FLAG && bitmask == WRAP_CURRY_FLAG) ||
+        (srcBitmask == WRAP_ARY_FLAG && bitmask == WRAP_REARG_FLAG && data[7].length <= source[8]) ||
+        (srcBitmask == (WRAP_ARY_FLAG | WRAP_REARG_FLAG) && source[7].length <= source[8] && bitmask == WRAP_CURRY_FLAG)
 
       // Exit early if metadata can't be merged.
       if (!(isCommon || isCombo)) {
-        return data;
+        return data
       }
       // Use source `thisArg` if available.
       if (srcBitmask & WRAP_BIND_FLAG) {
-        data[2] = source[2];
+        data[2] = source[2]
         // Set when currying a bound function.
-        newBitmask |= bitmask & WRAP_BIND_FLAG ? 0 : WRAP_CURRY_BOUND_FLAG;
+        newBitmask |= bitmask & WRAP_BIND_FLAG ? 0 : WRAP_CURRY_BOUND_FLAG
       }
       // Compose partial arguments.
-      var value = source[3];
+      var value = source[3]
       if (value) {
-        var partials = data[3];
-        data[3] = partials ? composeArgs(partials, value, source[4]) : value;
-        data[4] = partials ? replaceHolders(data[3], PLACEHOLDER) : source[4];
+        var partials = data[3]
+        data[3] = partials ? composeArgs(partials, value, source[4]) : value
+        data[4] = partials ? replaceHolders(data[3], PLACEHOLDER) : source[4]
       }
       // Compose partial right arguments.
-      value = source[5];
+      value = source[5]
       if (value) {
-        partials = data[5];
-        data[5] = partials ? composeArgsRight(partials, value, source[6]) : value;
-        data[6] = partials ? replaceHolders(data[5], PLACEHOLDER) : source[6];
+        partials = data[5]
+        data[5] = partials ? composeArgsRight(partials, value, source[6]) : value
+        data[6] = partials ? replaceHolders(data[5], PLACEHOLDER) : source[6]
       }
       // Use source `argPos` if available.
-      value = source[7];
+      value = source[7]
       if (value) {
-        data[7] = value;
+        data[7] = value
       }
       // Use source `ary` if it's smaller.
       if (srcBitmask & WRAP_ARY_FLAG) {
-        data[8] = data[8] == null ? source[8] : nativeMin(data[8], source[8]);
+        data[8] = data[8] == null ? source[8] : nativeMin(data[8], source[8])
       }
       // Use source `arity` if one is not provided.
       if (data[9] == null) {
-        data[9] = source[9];
+        data[9] = source[9]
       }
       // Use source `func` and merge bitmasks.
-      data[0] = source[0];
-      data[1] = newBitmask;
+      data[0] = source[0]
+      data[1] = newBitmask
 
-      return data;
+      return data
     }
 
     /**
@@ -6551,13 +6742,13 @@
      * @returns {Array} Returns the array of property names.
      */
     function nativeKeysIn(object) {
-      var result = [];
+      var result = []
       if (object != null) {
         for (var key in Object(object)) {
-          result.push(key);
+          result.push(key)
         }
       }
-      return result;
+      return result
     }
 
     /**
@@ -6568,7 +6759,7 @@
      * @returns {string} Returns the converted string.
      */
     function objectToString(value) {
-      return nativeObjectToString.call(value);
+      return nativeObjectToString.call(value)
     }
 
     /**
@@ -6581,24 +6772,24 @@
      * @returns {Function} Returns the new function.
      */
     function overRest(func, start, transform) {
-      start = nativeMax(start === undefined ? (func.length - 1) : start, 0);
+      start = nativeMax(start === undefined ? func.length - 1 : start, 0)
       return function() {
         var args = arguments,
-            index = -1,
-            length = nativeMax(args.length - start, 0),
-            array = Array(length);
+          index = -1,
+          length = nativeMax(args.length - start, 0),
+          array = Array(length)
 
         while (++index < length) {
-          array[index] = args[start + index];
+          array[index] = args[start + index]
         }
-        index = -1;
-        var otherArgs = Array(start + 1);
+        index = -1
+        var otherArgs = Array(start + 1)
         while (++index < start) {
-          otherArgs[index] = args[index];
+          otherArgs[index] = args[index]
         }
-        otherArgs[start] = transform(array);
-        return apply(func, this, otherArgs);
-      };
+        otherArgs[start] = transform(array)
+        return apply(func, this, otherArgs)
+      }
     }
 
     /**
@@ -6610,7 +6801,7 @@
      * @returns {*} Returns the parent value.
      */
     function parent(object, path) {
-      return path.length < 2 ? object : baseGet(object, baseSlice(path, 0, -1));
+      return path.length < 2 ? object : baseGet(object, baseSlice(path, 0, -1))
     }
 
     /**
@@ -6625,14 +6816,14 @@
      */
     function reorder(array, indexes) {
       var arrLength = array.length,
-          length = nativeMin(indexes.length, arrLength),
-          oldArray = copyArray(array);
+        length = nativeMin(indexes.length, arrLength),
+        oldArray = copyArray(array)
 
       while (length--) {
-        var index = indexes[length];
-        array[length] = isIndex(index, arrLength) ? oldArray[index] : undefined;
+        var index = indexes[length]
+        array[length] = isIndex(index, arrLength) ? oldArray[index] : undefined
       }
-      return array;
+      return array
     }
 
     /**
@@ -6649,7 +6840,7 @@
      * @param {*} data The metadata.
      * @returns {Function} Returns `func`.
      */
-    var setData = shortOut(baseSetData);
+    var setData = shortOut(baseSetData)
 
     /**
      * A simple wrapper around the global [`setTimeout`](https://mdn.io/setTimeout).
@@ -6659,9 +6850,11 @@
      * @param {number} wait The number of milliseconds to delay invocation.
      * @returns {number|Object} Returns the timer id or timeout object.
      */
-    var setTimeout = ctxSetTimeout || function(func, wait) {
-      return root.setTimeout(func, wait);
-    };
+    var setTimeout =
+      ctxSetTimeout ||
+      function(func, wait) {
+        return root.setTimeout(func, wait)
+      }
 
     /**
      * Sets the `toString` method of `func` to return `string`.
@@ -6671,7 +6864,7 @@
      * @param {Function} string The `toString` result.
      * @returns {Function} Returns `func`.
      */
-    var setToString = shortOut(baseSetToString);
+    var setToString = shortOut(baseSetToString)
 
     /**
      * Sets the `toString` method of `wrapper` to mimic the source of `reference`
@@ -6684,8 +6877,8 @@
      * @returns {Function} Returns `wrapper`.
      */
     function setWrapToString(wrapper, reference, bitmask) {
-      var source = (reference + '');
-      return setToString(wrapper, insertWrapDetails(source, updateWrapDetails(getWrapDetails(source), bitmask)));
+      var source = reference + ''
+      return setToString(wrapper, insertWrapDetails(source, updateWrapDetails(getWrapDetails(source), bitmask)))
     }
 
     /**
@@ -6699,22 +6892,22 @@
      */
     function shortOut(func) {
       var count = 0,
-          lastCalled = 0;
+        lastCalled = 0
 
       return function() {
         var stamp = nativeNow(),
-            remaining = HOT_SPAN - (stamp - lastCalled);
+          remaining = HOT_SPAN - (stamp - lastCalled)
 
-        lastCalled = stamp;
+        lastCalled = stamp
         if (remaining > 0) {
           if (++count >= HOT_COUNT) {
-            return arguments[0];
+            return arguments[0]
           }
         } else {
-          count = 0;
+          count = 0
         }
-        return func.apply(undefined, arguments);
-      };
+        return func.apply(undefined, arguments)
+      }
     }
 
     /**
@@ -6727,19 +6920,19 @@
      */
     function shuffleSelf(array, size) {
       var index = -1,
-          length = array.length,
-          lastIndex = length - 1;
+        length = array.length,
+        lastIndex = length - 1
 
-      size = size === undefined ? length : size;
+      size = size === undefined ? length : size
       while (++index < size) {
         var rand = baseRandom(index, lastIndex),
-            value = array[rand];
+          value = array[rand]
 
-        array[rand] = array[index];
-        array[index] = value;
+        array[rand] = array[index]
+        array[index] = value
       }
-      array.length = size;
-      return array;
+      array.length = size
+      return array
     }
 
     /**
@@ -6750,15 +6943,15 @@
      * @returns {Array} Returns the property path array.
      */
     var stringToPath = memoizeCapped(function(string) {
-      var result = [];
+      var result = []
       if (reLeadingDot.test(string)) {
-        result.push('');
+        result.push('')
       }
       string.replace(rePropName, function(match, number, quote, string) {
-        result.push(quote ? string.replace(reEscapeChar, '$1') : (number || match));
-      });
-      return result;
-    });
+        result.push(quote ? string.replace(reEscapeChar, '$1') : number || match)
+      })
+      return result
+    })
 
     /**
      * Converts `value` to a string key if it's not a string or symbol.
@@ -6769,10 +6962,10 @@
      */
     function toKey(value) {
       if (typeof value == 'string' || isSymbol(value)) {
-        return value;
+        return value
       }
-      var result = (value + '');
-      return (result == '0' && (1 / value) == -INFINITY) ? '-0' : result;
+      var result = value + ''
+      return result == '0' && 1 / value == -INFINITY ? '-0' : result
     }
 
     /**
@@ -6785,13 +6978,13 @@
     function toSource(func) {
       if (func != null) {
         try {
-          return funcToString.call(func);
+          return funcToString.call(func)
         } catch (e) {}
         try {
-          return (func + '');
+          return func + ''
         } catch (e) {}
       }
-      return '';
+      return ''
     }
 
     /**
@@ -6804,12 +6997,12 @@
      */
     function updateWrapDetails(details, bitmask) {
       arrayEach(wrapFlags, function(pair) {
-        var value = '_.' + pair[0];
-        if ((bitmask & pair[1]) && !arrayIncludes(details, value)) {
-          details.push(value);
+        var value = '_.' + pair[0]
+        if (bitmask & pair[1] && !arrayIncludes(details, value)) {
+          details.push(value)
         }
-      });
-      return details.sort();
+      })
+      return details.sort()
     }
 
     /**
@@ -6821,13 +7014,13 @@
      */
     function wrapperClone(wrapper) {
       if (wrapper instanceof LazyWrapper) {
-        return wrapper.clone();
+        return wrapper.clone()
       }
-      var result = new LodashWrapper(wrapper.__wrapped__, wrapper.__chain__);
-      result.__actions__ = copyArray(wrapper.__actions__);
-      result.__index__  = wrapper.__index__;
-      result.__values__ = wrapper.__values__;
-      return result;
+      var result = new LodashWrapper(wrapper.__wrapped__, wrapper.__chain__)
+      result.__actions__ = copyArray(wrapper.__actions__)
+      result.__index__ = wrapper.__index__
+      result.__values__ = wrapper.__values__
+      return result
     }
 
     /*------------------------------------------------------------------------*/
@@ -6854,23 +7047,23 @@
      * // => [['a', 'b', 'c'], ['d']]
      */
     function chunk(array, size, guard) {
-      if ((guard ? isIterateeCall(array, size, guard) : size === undefined)) {
-        size = 1;
+      if (guard ? isIterateeCall(array, size, guard) : size === undefined) {
+        size = 1
       } else {
-        size = nativeMax(toInteger(size), 0);
+        size = nativeMax(toInteger(size), 0)
       }
-      var length = array == null ? 0 : array.length;
+      var length = array == null ? 0 : array.length
       if (!length || size < 1) {
-        return [];
+        return []
       }
       var index = 0,
-          resIndex = 0,
-          result = Array(nativeCeil(length / size));
+        resIndex = 0,
+        result = Array(nativeCeil(length / size))
 
       while (index < length) {
-        result[resIndex++] = baseSlice(array, index, (index += size));
+        result[resIndex++] = baseSlice(array, index, (index += size))
       }
-      return result;
+      return result
     }
 
     /**
@@ -6890,17 +7083,17 @@
      */
     function compact(array) {
       var index = -1,
-          length = array == null ? 0 : array.length,
-          resIndex = 0,
-          result = [];
+        length = array == null ? 0 : array.length,
+        resIndex = 0,
+        result = []
 
       while (++index < length) {
-        var value = array[index];
+        var value = array[index]
         if (value) {
-          result[resIndex++] = value;
+          result[resIndex++] = value
         }
       }
-      return result;
+      return result
     }
 
     /**
@@ -6926,18 +7119,18 @@
      * // => [1]
      */
     function concat() {
-      var length = arguments.length;
+      var length = arguments.length
       if (!length) {
-        return [];
+        return []
       }
       var args = Array(length - 1),
-          array = arguments[0],
-          index = length;
+        array = arguments[0],
+        index = length
 
       while (index--) {
-        args[index - 1] = arguments[index];
+        args[index - 1] = arguments[index]
       }
-      return arrayPush(isArray(array) ? copyArray(array) : [array], baseFlatten(args, 1));
+      return arrayPush(isArray(array) ? copyArray(array) : [array], baseFlatten(args, 1))
     }
 
     /**
@@ -6962,10 +7155,8 @@
      * // => [1]
      */
     var difference = baseRest(function(array, values) {
-      return isArrayLikeObject(array)
-        ? baseDifference(array, baseFlatten(values, 1, isArrayLikeObject, true))
-        : [];
-    });
+      return isArrayLikeObject(array) ? baseDifference(array, baseFlatten(values, 1, isArrayLikeObject, true)) : []
+    })
 
     /**
      * This method is like `_.difference` except that it accepts `iteratee` which
@@ -6994,14 +7185,14 @@
      * // => [{ 'x': 2 }]
      */
     var differenceBy = baseRest(function(array, values) {
-      var iteratee = last(values);
+      var iteratee = last(values)
       if (isArrayLikeObject(iteratee)) {
-        iteratee = undefined;
+        iteratee = undefined
       }
       return isArrayLikeObject(array)
         ? baseDifference(array, baseFlatten(values, 1, isArrayLikeObject, true), getIteratee(iteratee, 2))
-        : [];
-    });
+        : []
+    })
 
     /**
      * This method is like `_.difference` except that it accepts `comparator`
@@ -7027,14 +7218,14 @@
      * // => [{ 'x': 2, 'y': 1 }]
      */
     var differenceWith = baseRest(function(array, values) {
-      var comparator = last(values);
+      var comparator = last(values)
       if (isArrayLikeObject(comparator)) {
-        comparator = undefined;
+        comparator = undefined
       }
       return isArrayLikeObject(array)
         ? baseDifference(array, baseFlatten(values, 1, isArrayLikeObject, true), undefined, comparator)
-        : [];
-    });
+        : []
+    })
 
     /**
      * Creates a slice of `array` with `n` elements dropped from the beginning.
@@ -7062,12 +7253,12 @@
      * // => [1, 2, 3]
      */
     function drop(array, n, guard) {
-      var length = array == null ? 0 : array.length;
+      var length = array == null ? 0 : array.length
       if (!length) {
-        return [];
+        return []
       }
-      n = (guard || n === undefined) ? 1 : toInteger(n);
-      return baseSlice(array, n < 0 ? 0 : n, length);
+      n = guard || n === undefined ? 1 : toInteger(n)
+      return baseSlice(array, n < 0 ? 0 : n, length)
     }
 
     /**
@@ -7096,13 +7287,13 @@
      * // => [1, 2, 3]
      */
     function dropRight(array, n, guard) {
-      var length = array == null ? 0 : array.length;
+      var length = array == null ? 0 : array.length
       if (!length) {
-        return [];
+        return []
       }
-      n = (guard || n === undefined) ? 1 : toInteger(n);
-      n = length - n;
-      return baseSlice(array, 0, n < 0 ? 0 : n);
+      n = guard || n === undefined ? 1 : toInteger(n)
+      n = length - n
+      return baseSlice(array, 0, n < 0 ? 0 : n)
     }
 
     /**
@@ -7141,9 +7332,7 @@
      * // => objects for ['barney', 'fred', 'pebbles']
      */
     function dropRightWhile(array, predicate) {
-      return (array && array.length)
-        ? baseWhile(array, getIteratee(predicate, 3), true, true)
-        : [];
+      return array && array.length ? baseWhile(array, getIteratee(predicate, 3), true, true) : []
     }
 
     /**
@@ -7182,9 +7371,7 @@
      * // => objects for ['barney', 'fred', 'pebbles']
      */
     function dropWhile(array, predicate) {
-      return (array && array.length)
-        ? baseWhile(array, getIteratee(predicate, 3), true)
-        : [];
+      return array && array.length ? baseWhile(array, getIteratee(predicate, 3), true) : []
     }
 
     /**
@@ -7217,15 +7404,15 @@
      * // => [4, '*', '*', 10]
      */
     function fill(array, value, start, end) {
-      var length = array == null ? 0 : array.length;
+      var length = array == null ? 0 : array.length
       if (!length) {
-        return [];
+        return []
       }
       if (start && typeof start != 'number' && isIterateeCall(array, value, start)) {
-        start = 0;
-        end = length;
+        start = 0
+        end = length
       }
-      return baseFill(array, value, start, end);
+      return baseFill(array, value, start, end)
     }
 
     /**
@@ -7264,15 +7451,15 @@
      * // => 2
      */
     function findIndex(array, predicate, fromIndex) {
-      var length = array == null ? 0 : array.length;
+      var length = array == null ? 0 : array.length
       if (!length) {
-        return -1;
+        return -1
       }
-      var index = fromIndex == null ? 0 : toInteger(fromIndex);
+      var index = fromIndex == null ? 0 : toInteger(fromIndex)
       if (index < 0) {
-        index = nativeMax(length + index, 0);
+        index = nativeMax(length + index, 0)
       }
-      return baseFindIndex(array, getIteratee(predicate, 3), index);
+      return baseFindIndex(array, getIteratee(predicate, 3), index)
     }
 
     /**
@@ -7311,18 +7498,16 @@
      * // => 0
      */
     function findLastIndex(array, predicate, fromIndex) {
-      var length = array == null ? 0 : array.length;
+      var length = array == null ? 0 : array.length
       if (!length) {
-        return -1;
+        return -1
       }
-      var index = length - 1;
+      var index = length - 1
       if (fromIndex !== undefined) {
-        index = toInteger(fromIndex);
-        index = fromIndex < 0
-          ? nativeMax(length + index, 0)
-          : nativeMin(index, length - 1);
+        index = toInteger(fromIndex)
+        index = fromIndex < 0 ? nativeMax(length + index, 0) : nativeMin(index, length - 1)
       }
-      return baseFindIndex(array, getIteratee(predicate, 3), index, true);
+      return baseFindIndex(array, getIteratee(predicate, 3), index, true)
     }
 
     /**
@@ -7340,8 +7525,8 @@
      * // => [1, 2, [3, [4]], 5]
      */
     function flatten(array) {
-      var length = array == null ? 0 : array.length;
-      return length ? baseFlatten(array, 1) : [];
+      var length = array == null ? 0 : array.length
+      return length ? baseFlatten(array, 1) : []
     }
 
     /**
@@ -7359,8 +7544,8 @@
      * // => [1, 2, 3, 4, 5]
      */
     function flattenDeep(array) {
-      var length = array == null ? 0 : array.length;
-      return length ? baseFlatten(array, INFINITY) : [];
+      var length = array == null ? 0 : array.length
+      return length ? baseFlatten(array, INFINITY) : []
     }
 
     /**
@@ -7384,12 +7569,12 @@
      * // => [1, 2, 3, [4], 5]
      */
     function flattenDepth(array, depth) {
-      var length = array == null ? 0 : array.length;
+      var length = array == null ? 0 : array.length
       if (!length) {
-        return [];
+        return []
       }
-      depth = depth === undefined ? 1 : toInteger(depth);
-      return baseFlatten(array, depth);
+      depth = depth === undefined ? 1 : toInteger(depth)
+      return baseFlatten(array, depth)
     }
 
     /**
@@ -7409,14 +7594,14 @@
      */
     function fromPairs(pairs) {
       var index = -1,
-          length = pairs == null ? 0 : pairs.length,
-          result = {};
+        length = pairs == null ? 0 : pairs.length,
+        result = {}
 
       while (++index < length) {
-        var pair = pairs[index];
-        result[pair[0]] = pair[1];
+        var pair = pairs[index]
+        result[pair[0]] = pair[1]
       }
-      return result;
+      return result
     }
 
     /**
@@ -7438,7 +7623,7 @@
      * // => undefined
      */
     function head(array) {
-      return (array && array.length) ? array[0] : undefined;
+      return array && array.length ? array[0] : undefined
     }
 
     /**
@@ -7465,15 +7650,15 @@
      * // => 3
      */
     function indexOf(array, value, fromIndex) {
-      var length = array == null ? 0 : array.length;
+      var length = array == null ? 0 : array.length
       if (!length) {
-        return -1;
+        return -1
       }
-      var index = fromIndex == null ? 0 : toInteger(fromIndex);
+      var index = fromIndex == null ? 0 : toInteger(fromIndex)
       if (index < 0) {
-        index = nativeMax(length + index, 0);
+        index = nativeMax(length + index, 0)
       }
-      return baseIndexOf(array, value, index);
+      return baseIndexOf(array, value, index)
     }
 
     /**
@@ -7491,8 +7676,8 @@
      * // => [1, 2]
      */
     function initial(array) {
-      var length = array == null ? 0 : array.length;
-      return length ? baseSlice(array, 0, -1) : [];
+      var length = array == null ? 0 : array.length
+      return length ? baseSlice(array, 0, -1) : []
     }
 
     /**
@@ -7513,11 +7698,9 @@
      * // => [2]
      */
     var intersection = baseRest(function(arrays) {
-      var mapped = arrayMap(arrays, castArrayLikeObject);
-      return (mapped.length && mapped[0] === arrays[0])
-        ? baseIntersection(mapped)
-        : [];
-    });
+      var mapped = arrayMap(arrays, castArrayLikeObject)
+      return mapped.length && mapped[0] === arrays[0] ? baseIntersection(mapped) : []
+    })
 
     /**
      * This method is like `_.intersection` except that it accepts `iteratee`
@@ -7544,17 +7727,15 @@
      */
     var intersectionBy = baseRest(function(arrays) {
       var iteratee = last(arrays),
-          mapped = arrayMap(arrays, castArrayLikeObject);
+        mapped = arrayMap(arrays, castArrayLikeObject)
 
       if (iteratee === last(mapped)) {
-        iteratee = undefined;
+        iteratee = undefined
       } else {
-        mapped.pop();
+        mapped.pop()
       }
-      return (mapped.length && mapped[0] === arrays[0])
-        ? baseIntersection(mapped, getIteratee(iteratee, 2))
-        : [];
-    });
+      return mapped.length && mapped[0] === arrays[0] ? baseIntersection(mapped, getIteratee(iteratee, 2)) : []
+    })
 
     /**
      * This method is like `_.intersection` except that it accepts `comparator`
@@ -7579,16 +7760,14 @@
      */
     var intersectionWith = baseRest(function(arrays) {
       var comparator = last(arrays),
-          mapped = arrayMap(arrays, castArrayLikeObject);
+        mapped = arrayMap(arrays, castArrayLikeObject)
 
-      comparator = typeof comparator == 'function' ? comparator : undefined;
+      comparator = typeof comparator == 'function' ? comparator : undefined
       if (comparator) {
-        mapped.pop();
+        mapped.pop()
       }
-      return (mapped.length && mapped[0] === arrays[0])
-        ? baseIntersection(mapped, undefined, comparator)
-        : [];
-    });
+      return mapped.length && mapped[0] === arrays[0] ? baseIntersection(mapped, undefined, comparator) : []
+    })
 
     /**
      * Converts all elements in `array` into a string separated by `separator`.
@@ -7606,7 +7785,7 @@
      * // => 'a~b~c'
      */
     function join(array, separator) {
-      return array == null ? '' : nativeJoin.call(array, separator);
+      return array == null ? '' : nativeJoin.call(array, separator)
     }
 
     /**
@@ -7624,8 +7803,8 @@
      * // => 3
      */
     function last(array) {
-      var length = array == null ? 0 : array.length;
-      return length ? array[length - 1] : undefined;
+      var length = array == null ? 0 : array.length
+      return length ? array[length - 1] : undefined
     }
 
     /**
@@ -7650,18 +7829,16 @@
      * // => 1
      */
     function lastIndexOf(array, value, fromIndex) {
-      var length = array == null ? 0 : array.length;
+      var length = array == null ? 0 : array.length
       if (!length) {
-        return -1;
+        return -1
       }
-      var index = length;
+      var index = length
       if (fromIndex !== undefined) {
-        index = toInteger(fromIndex);
-        index = index < 0 ? nativeMax(length + index, 0) : nativeMin(index, length - 1);
+        index = toInteger(fromIndex)
+        index = index < 0 ? nativeMax(length + index, 0) : nativeMin(index, length - 1)
       }
-      return value === value
-        ? strictLastIndexOf(array, value, index)
-        : baseFindIndex(array, baseIsNaN, index, true);
+      return value === value ? strictLastIndexOf(array, value, index) : baseFindIndex(array, baseIsNaN, index, true)
     }
 
     /**
@@ -7686,7 +7863,7 @@
      * // => 'c';
      */
     function nth(array, n) {
-      return (array && array.length) ? baseNth(array, toInteger(n)) : undefined;
+      return array && array.length ? baseNth(array, toInteger(n)) : undefined
     }
 
     /**
@@ -7712,7 +7889,7 @@
      * console.log(array);
      * // => ['b', 'b']
      */
-    var pull = baseRest(pullAll);
+    var pull = baseRest(pullAll)
 
     /**
      * This method is like `_.pull` except that it accepts an array of values to remove.
@@ -7735,9 +7912,7 @@
      * // => ['b', 'b']
      */
     function pullAll(array, values) {
-      return (array && array.length && values && values.length)
-        ? basePullAll(array, values)
-        : array;
+      return array && array.length && values && values.length ? basePullAll(array, values) : array
     }
 
     /**
@@ -7764,9 +7939,9 @@
      * // => [{ 'x': 2 }]
      */
     function pullAllBy(array, values, iteratee) {
-      return (array && array.length && values && values.length)
+      return array && array.length && values && values.length
         ? basePullAll(array, values, getIteratee(iteratee, 2))
-        : array;
+        : array
     }
 
     /**
@@ -7793,9 +7968,9 @@
      * // => [{ 'x': 1, 'y': 2 }, { 'x': 5, 'y': 6 }]
      */
     function pullAllWith(array, values, comparator) {
-      return (array && array.length && values && values.length)
+      return array && array.length && values && values.length
         ? basePullAll(array, values, undefined, comparator)
-        : array;
+        : array
     }
 
     /**
@@ -7824,14 +7999,17 @@
      */
     var pullAt = flatRest(function(array, indexes) {
       var length = array == null ? 0 : array.length,
-          result = baseAt(array, indexes);
+        result = baseAt(array, indexes)
 
-      basePullAt(array, arrayMap(indexes, function(index) {
-        return isIndex(index, length) ? +index : index;
-      }).sort(compareAscending));
+      basePullAt(
+        array,
+        arrayMap(indexes, function(index) {
+          return isIndex(index, length) ? +index : index
+        }).sort(compareAscending)
+      )
 
-      return result;
-    });
+      return result
+    })
 
     /**
      * Removes all elements from `array` that `predicate` returns truthy for
@@ -7862,24 +8040,24 @@
      * // => [2, 4]
      */
     function remove(array, predicate) {
-      var result = [];
+      var result = []
       if (!(array && array.length)) {
-        return result;
+        return result
       }
       var index = -1,
-          indexes = [],
-          length = array.length;
+        indexes = [],
+        length = array.length
 
-      predicate = getIteratee(predicate, 3);
+      predicate = getIteratee(predicate, 3)
       while (++index < length) {
-        var value = array[index];
+        var value = array[index]
         if (predicate(value, index, array)) {
-          result.push(value);
-          indexes.push(index);
+          result.push(value)
+          indexes.push(index)
         }
       }
-      basePullAt(array, indexes);
-      return result;
+      basePullAt(array, indexes)
+      return result
     }
 
     /**
@@ -7906,7 +8084,7 @@
      * // => [3, 2, 1]
      */
     function reverse(array) {
-      return array == null ? array : nativeReverse.call(array);
+      return array == null ? array : nativeReverse.call(array)
     }
 
     /**
@@ -7926,19 +8104,18 @@
      * @returns {Array} Returns the slice of `array`.
      */
     function slice(array, start, end) {
-      var length = array == null ? 0 : array.length;
+      var length = array == null ? 0 : array.length
       if (!length) {
-        return [];
+        return []
       }
       if (end && typeof end != 'number' && isIterateeCall(array, start, end)) {
-        start = 0;
-        end = length;
+        start = 0
+        end = length
+      } else {
+        start = start == null ? 0 : toInteger(start)
+        end = end === undefined ? length : toInteger(end)
       }
-      else {
-        start = start == null ? 0 : toInteger(start);
-        end = end === undefined ? length : toInteger(end);
-      }
-      return baseSlice(array, start, end);
+      return baseSlice(array, start, end)
     }
 
     /**
@@ -7959,7 +8136,7 @@
      * // => 1
      */
     function sortedIndex(array, value) {
-      return baseSortedIndex(array, value);
+      return baseSortedIndex(array, value)
     }
 
     /**
@@ -7988,7 +8165,7 @@
      * // => 0
      */
     function sortedIndexBy(array, value, iteratee) {
-      return baseSortedIndexBy(array, value, getIteratee(iteratee, 2));
+      return baseSortedIndexBy(array, value, getIteratee(iteratee, 2))
     }
 
     /**
@@ -8008,14 +8185,14 @@
      * // => 1
      */
     function sortedIndexOf(array, value) {
-      var length = array == null ? 0 : array.length;
+      var length = array == null ? 0 : array.length
       if (length) {
-        var index = baseSortedIndex(array, value);
+        var index = baseSortedIndex(array, value)
         if (index < length && eq(array[index], value)) {
-          return index;
+          return index
         }
       }
-      return -1;
+      return -1
     }
 
     /**
@@ -8037,7 +8214,7 @@
      * // => 4
      */
     function sortedLastIndex(array, value) {
-      return baseSortedIndex(array, value, true);
+      return baseSortedIndex(array, value, true)
     }
 
     /**
@@ -8066,7 +8243,7 @@
      * // => 1
      */
     function sortedLastIndexBy(array, value, iteratee) {
-      return baseSortedIndexBy(array, value, getIteratee(iteratee, 2), true);
+      return baseSortedIndexBy(array, value, getIteratee(iteratee, 2), true)
     }
 
     /**
@@ -8086,14 +8263,14 @@
      * // => 3
      */
     function sortedLastIndexOf(array, value) {
-      var length = array == null ? 0 : array.length;
+      var length = array == null ? 0 : array.length
       if (length) {
-        var index = baseSortedIndex(array, value, true) - 1;
+        var index = baseSortedIndex(array, value, true) - 1
         if (eq(array[index], value)) {
-          return index;
+          return index
         }
       }
-      return -1;
+      return -1
     }
 
     /**
@@ -8112,9 +8289,7 @@
      * // => [1, 2]
      */
     function sortedUniq(array) {
-      return (array && array.length)
-        ? baseSortedUniq(array)
-        : [];
+      return array && array.length ? baseSortedUniq(array) : []
     }
 
     /**
@@ -8134,9 +8309,7 @@
      * // => [1.1, 2.3]
      */
     function sortedUniqBy(array, iteratee) {
-      return (array && array.length)
-        ? baseSortedUniq(array, getIteratee(iteratee, 2))
-        : [];
+      return array && array.length ? baseSortedUniq(array, getIteratee(iteratee, 2)) : []
     }
 
     /**
@@ -8154,8 +8327,8 @@
      * // => [2, 3]
      */
     function tail(array) {
-      var length = array == null ? 0 : array.length;
-      return length ? baseSlice(array, 1, length) : [];
+      var length = array == null ? 0 : array.length
+      return length ? baseSlice(array, 1, length) : []
     }
 
     /**
@@ -8185,10 +8358,10 @@
      */
     function take(array, n, guard) {
       if (!(array && array.length)) {
-        return [];
+        return []
       }
-      n = (guard || n === undefined) ? 1 : toInteger(n);
-      return baseSlice(array, 0, n < 0 ? 0 : n);
+      n = guard || n === undefined ? 1 : toInteger(n)
+      return baseSlice(array, 0, n < 0 ? 0 : n)
     }
 
     /**
@@ -8217,13 +8390,13 @@
      * // => []
      */
     function takeRight(array, n, guard) {
-      var length = array == null ? 0 : array.length;
+      var length = array == null ? 0 : array.length
       if (!length) {
-        return [];
+        return []
       }
-      n = (guard || n === undefined) ? 1 : toInteger(n);
-      n = length - n;
-      return baseSlice(array, n < 0 ? 0 : n, length);
+      n = guard || n === undefined ? 1 : toInteger(n)
+      n = length - n
+      return baseSlice(array, n < 0 ? 0 : n, length)
     }
 
     /**
@@ -8262,9 +8435,7 @@
      * // => []
      */
     function takeRightWhile(array, predicate) {
-      return (array && array.length)
-        ? baseWhile(array, getIteratee(predicate, 3), false, true)
-        : [];
+      return array && array.length ? baseWhile(array, getIteratee(predicate, 3), false, true) : []
     }
 
     /**
@@ -8303,9 +8474,7 @@
      * // => []
      */
     function takeWhile(array, predicate) {
-      return (array && array.length)
-        ? baseWhile(array, getIteratee(predicate, 3))
-        : [];
+      return array && array.length ? baseWhile(array, getIteratee(predicate, 3)) : []
     }
 
     /**
@@ -8325,8 +8494,8 @@
      * // => [2, 1]
      */
     var union = baseRest(function(arrays) {
-      return baseUniq(baseFlatten(arrays, 1, isArrayLikeObject, true));
-    });
+      return baseUniq(baseFlatten(arrays, 1, isArrayLikeObject, true))
+    })
 
     /**
      * This method is like `_.union` except that it accepts `iteratee` which is
@@ -8352,12 +8521,12 @@
      * // => [{ 'x': 1 }, { 'x': 2 }]
      */
     var unionBy = baseRest(function(arrays) {
-      var iteratee = last(arrays);
+      var iteratee = last(arrays)
       if (isArrayLikeObject(iteratee)) {
-        iteratee = undefined;
+        iteratee = undefined
       }
-      return baseUniq(baseFlatten(arrays, 1, isArrayLikeObject, true), getIteratee(iteratee, 2));
-    });
+      return baseUniq(baseFlatten(arrays, 1, isArrayLikeObject, true), getIteratee(iteratee, 2))
+    })
 
     /**
      * This method is like `_.union` except that it accepts `comparator` which
@@ -8381,10 +8550,10 @@
      * // => [{ 'x': 1, 'y': 2 }, { 'x': 2, 'y': 1 }, { 'x': 1, 'y': 1 }]
      */
     var unionWith = baseRest(function(arrays) {
-      var comparator = last(arrays);
-      comparator = typeof comparator == 'function' ? comparator : undefined;
-      return baseUniq(baseFlatten(arrays, 1, isArrayLikeObject, true), undefined, comparator);
-    });
+      var comparator = last(arrays)
+      comparator = typeof comparator == 'function' ? comparator : undefined
+      return baseUniq(baseFlatten(arrays, 1, isArrayLikeObject, true), undefined, comparator)
+    })
 
     /**
      * Creates a duplicate-free version of an array, using
@@ -8405,7 +8574,7 @@
      * // => [2, 1]
      */
     function uniq(array) {
-      return (array && array.length) ? baseUniq(array) : [];
+      return array && array.length ? baseUniq(array) : []
     }
 
     /**
@@ -8432,7 +8601,7 @@
      * // => [{ 'x': 1 }, { 'x': 2 }]
      */
     function uniqBy(array, iteratee) {
-      return (array && array.length) ? baseUniq(array, getIteratee(iteratee, 2)) : [];
+      return array && array.length ? baseUniq(array, getIteratee(iteratee, 2)) : []
     }
 
     /**
@@ -8456,8 +8625,8 @@
      * // => [{ 'x': 1, 'y': 2 }, { 'x': 2, 'y': 1 }]
      */
     function uniqWith(array, comparator) {
-      comparator = typeof comparator == 'function' ? comparator : undefined;
-      return (array && array.length) ? baseUniq(array, undefined, comparator) : [];
+      comparator = typeof comparator == 'function' ? comparator : undefined
+      return array && array.length ? baseUniq(array, undefined, comparator) : []
     }
 
     /**
@@ -8481,18 +8650,18 @@
      */
     function unzip(array) {
       if (!(array && array.length)) {
-        return [];
+        return []
       }
-      var length = 0;
+      var length = 0
       array = arrayFilter(array, function(group) {
         if (isArrayLikeObject(group)) {
-          length = nativeMax(group.length, length);
-          return true;
+          length = nativeMax(group.length, length)
+          return true
         }
-      });
+      })
       return baseTimes(length, function(index) {
-        return arrayMap(array, baseProperty(index));
-      });
+        return arrayMap(array, baseProperty(index))
+      })
     }
 
     /**
@@ -8518,15 +8687,15 @@
      */
     function unzipWith(array, iteratee) {
       if (!(array && array.length)) {
-        return [];
+        return []
       }
-      var result = unzip(array);
+      var result = unzip(array)
       if (iteratee == null) {
-        return result;
+        return result
       }
       return arrayMap(result, function(group) {
-        return apply(iteratee, undefined, group);
-      });
+        return apply(iteratee, undefined, group)
+      })
     }
 
     /**
@@ -8550,10 +8719,8 @@
      * // => [3]
      */
     var without = baseRest(function(array, values) {
-      return isArrayLikeObject(array)
-        ? baseDifference(array, values)
-        : [];
-    });
+      return isArrayLikeObject(array) ? baseDifference(array, values) : []
+    })
 
     /**
      * Creates an array of unique values that is the
@@ -8574,8 +8741,8 @@
      * // => [1, 3]
      */
     var xor = baseRest(function(arrays) {
-      return baseXor(arrayFilter(arrays, isArrayLikeObject));
-    });
+      return baseXor(arrayFilter(arrays, isArrayLikeObject))
+    })
 
     /**
      * This method is like `_.xor` except that it accepts `iteratee` which is
@@ -8601,12 +8768,12 @@
      * // => [{ 'x': 2 }]
      */
     var xorBy = baseRest(function(arrays) {
-      var iteratee = last(arrays);
+      var iteratee = last(arrays)
       if (isArrayLikeObject(iteratee)) {
-        iteratee = undefined;
+        iteratee = undefined
       }
-      return baseXor(arrayFilter(arrays, isArrayLikeObject), getIteratee(iteratee, 2));
-    });
+      return baseXor(arrayFilter(arrays, isArrayLikeObject), getIteratee(iteratee, 2))
+    })
 
     /**
      * This method is like `_.xor` except that it accepts `comparator` which is
@@ -8630,10 +8797,10 @@
      * // => [{ 'x': 2, 'y': 1 }, { 'x': 1, 'y': 1 }]
      */
     var xorWith = baseRest(function(arrays) {
-      var comparator = last(arrays);
-      comparator = typeof comparator == 'function' ? comparator : undefined;
-      return baseXor(arrayFilter(arrays, isArrayLikeObject), undefined, comparator);
-    });
+      var comparator = last(arrays)
+      comparator = typeof comparator == 'function' ? comparator : undefined
+      return baseXor(arrayFilter(arrays, isArrayLikeObject), undefined, comparator)
+    })
 
     /**
      * Creates an array of grouped elements, the first of which contains the
@@ -8651,7 +8818,7 @@
      * _.zip(['a', 'b'], [1, 2], [true, false]);
      * // => [['a', 1, true], ['b', 2, false]]
      */
-    var zip = baseRest(unzip);
+    var zip = baseRest(unzip)
 
     /**
      * This method is like `_.fromPairs` except that it accepts two arrays,
@@ -8670,7 +8837,7 @@
      * // => { 'a': 1, 'b': 2 }
      */
     function zipObject(props, values) {
-      return baseZipObject(props || [], values || [], assignValue);
+      return baseZipObject(props || [], values || [], assignValue)
     }
 
     /**
@@ -8689,7 +8856,7 @@
      * // => { 'a': { 'b': [{ 'c': 1 }, { 'd': 2 }] } }
      */
     function zipObjectDeep(props, values) {
-      return baseZipObject(props || [], values || [], baseSet);
+      return baseZipObject(props || [], values || [], baseSet)
     }
 
     /**
@@ -8714,11 +8881,11 @@
      */
     var zipWith = baseRest(function(arrays) {
       var length = arrays.length,
-          iteratee = length > 1 ? arrays[length - 1] : undefined;
+        iteratee = length > 1 ? arrays[length - 1] : undefined
 
-      iteratee = typeof iteratee == 'function' ? (arrays.pop(), iteratee) : undefined;
-      return unzipWith(arrays, iteratee);
-    });
+      iteratee = typeof iteratee == 'function' ? (arrays.pop(), iteratee) : undefined
+      return unzipWith(arrays, iteratee)
+    })
 
     /*------------------------------------------------------------------------*/
 
@@ -8752,9 +8919,9 @@
      * // => 'pebbles is 1'
      */
     function chain(value) {
-      var result = lodash(value);
-      result.__chain__ = true;
-      return result;
+      var result = lodash(value)
+      result.__chain__ = true
+      return result
     }
 
     /**
@@ -8781,8 +8948,8 @@
      * // => [2, 1]
      */
     function tap(value, interceptor) {
-      interceptor(value);
-      return value;
+      interceptor(value)
+      return value
     }
 
     /**
@@ -8809,7 +8976,7 @@
      * // => ['abc']
      */
     function thru(value, interceptor) {
-      return interceptor(value);
+      return interceptor(value)
     }
 
     /**
@@ -8830,27 +8997,28 @@
      */
     var wrapperAt = flatRest(function(paths) {
       var length = paths.length,
-          start = length ? paths[0] : 0,
-          value = this.__wrapped__,
-          interceptor = function(object) { return baseAt(object, paths); };
+        start = length ? paths[0] : 0,
+        value = this.__wrapped__,
+        interceptor = function(object) {
+          return baseAt(object, paths)
+        }
 
-      if (length > 1 || this.__actions__.length ||
-          !(value instanceof LazyWrapper) || !isIndex(start)) {
-        return this.thru(interceptor);
+      if (length > 1 || this.__actions__.length || !(value instanceof LazyWrapper) || !isIndex(start)) {
+        return this.thru(interceptor)
       }
-      value = value.slice(start, +start + (length ? 1 : 0));
+      value = value.slice(start, +start + (length ? 1 : 0))
       value.__actions__.push({
-        'func': thru,
-        'args': [interceptor],
-        'thisArg': undefined
-      });
+        func: thru,
+        args: [interceptor],
+        thisArg: undefined
+      })
       return new LodashWrapper(value, this.__chain__).thru(function(array) {
         if (length && !array.length) {
-          array.push(undefined);
+          array.push(undefined)
         }
-        return array;
-      });
-    });
+        return array
+      })
+    })
 
     /**
      * Creates a `lodash` wrapper instance with explicit method chain sequences enabled.
@@ -8880,7 +9048,7 @@
      * // => { 'user': 'barney' }
      */
     function wrapperChain() {
-      return chain(this);
+      return chain(this)
     }
 
     /**
@@ -8910,7 +9078,7 @@
      * // => [1, 2, 3]
      */
     function wrapperCommit() {
-      return new LodashWrapper(this.value(), this.__chain__);
+      return new LodashWrapper(this.value(), this.__chain__)
     }
 
     /**
@@ -8937,12 +9105,12 @@
      */
     function wrapperNext() {
       if (this.__values__ === undefined) {
-        this.__values__ = toArray(this.value());
+        this.__values__ = toArray(this.value())
       }
       var done = this.__index__ >= this.__values__.length,
-          value = done ? undefined : this.__values__[this.__index__++];
+        value = done ? undefined : this.__values__[this.__index__++]
 
-      return { 'done': done, 'value': value };
+      return {done: done, value: value}
     }
 
     /**
@@ -8964,7 +9132,7 @@
      * // => [1, 2]
      */
     function wrapperToIterator() {
-      return this;
+      return this
     }
 
     /**
@@ -8993,22 +9161,22 @@
      */
     function wrapperPlant(value) {
       var result,
-          parent = this;
+        parent = this
 
       while (parent instanceof baseLodash) {
-        var clone = wrapperClone(parent);
-        clone.__index__ = 0;
-        clone.__values__ = undefined;
+        var clone = wrapperClone(parent)
+        clone.__index__ = 0
+        clone.__values__ = undefined
         if (result) {
-          previous.__wrapped__ = clone;
+          previous.__wrapped__ = clone
         } else {
-          result = clone;
+          result = clone
         }
-        var previous = clone;
-        parent = parent.__wrapped__;
+        var previous = clone
+        parent = parent.__wrapped__
       }
-      previous.__wrapped__ = value;
-      return result;
+      previous.__wrapped__ = value
+      return result
     }
 
     /**
@@ -9032,21 +9200,21 @@
      * // => [3, 2, 1]
      */
     function wrapperReverse() {
-      var value = this.__wrapped__;
+      var value = this.__wrapped__
       if (value instanceof LazyWrapper) {
-        var wrapped = value;
+        var wrapped = value
         if (this.__actions__.length) {
-          wrapped = new LazyWrapper(this);
+          wrapped = new LazyWrapper(this)
         }
-        wrapped = wrapped.reverse();
+        wrapped = wrapped.reverse()
         wrapped.__actions__.push({
-          'func': thru,
-          'args': [reverse],
-          'thisArg': undefined
-        });
-        return new LodashWrapper(wrapped, this.__chain__);
+          func: thru,
+          args: [reverse],
+          thisArg: undefined
+        })
+        return new LodashWrapper(wrapped, this.__chain__)
       }
-      return this.thru(reverse);
+      return this.thru(reverse)
     }
 
     /**
@@ -9064,7 +9232,7 @@
      * // => [1, 2, 3]
      */
     function wrapperValue() {
-      return baseWrapperValue(this.__wrapped__, this.__actions__);
+      return baseWrapperValue(this.__wrapped__, this.__actions__)
     }
 
     /*------------------------------------------------------------------------*/
@@ -9093,11 +9261,11 @@
      */
     var countBy = createAggregator(function(result, value, key) {
       if (hasOwnProperty.call(result, key)) {
-        ++result[key];
+        ++result[key]
       } else {
-        baseAssignValue(result, key, 1);
+        baseAssignValue(result, key, 1)
       }
-    });
+    })
 
     /**
      * Checks if `predicate` returns truthy for **all** elements of `collection`.
@@ -9141,11 +9309,11 @@
      * // => false
      */
     function every(collection, predicate, guard) {
-      var func = isArray(collection) ? arrayEvery : baseEvery;
+      var func = isArray(collection) ? arrayEvery : baseEvery
       if (guard && isIterateeCall(collection, predicate, guard)) {
-        predicate = undefined;
+        predicate = undefined
       }
-      return func(collection, getIteratee(predicate, 3));
+      return func(collection, getIteratee(predicate, 3))
     }
 
     /**
@@ -9186,8 +9354,8 @@
      * // => objects for ['barney']
      */
     function filter(collection, predicate) {
-      var func = isArray(collection) ? arrayFilter : baseFilter;
-      return func(collection, getIteratee(predicate, 3));
+      var func = isArray(collection) ? arrayFilter : baseFilter
+      return func(collection, getIteratee(predicate, 3))
     }
 
     /**
@@ -9226,7 +9394,7 @@
      * _.find(users, 'active');
      * // => object for 'barney'
      */
-    var find = createFind(findIndex);
+    var find = createFind(findIndex)
 
     /**
      * This method is like `_.find` except that it iterates over elements of
@@ -9247,7 +9415,7 @@
      * });
      * // => 3
      */
-    var findLast = createFind(findLastIndex);
+    var findLast = createFind(findLastIndex)
 
     /**
      * Creates a flattened array of values by running each element in `collection`
@@ -9271,7 +9439,7 @@
      * // => [1, 1, 2, 2]
      */
     function flatMap(collection, iteratee) {
-      return baseFlatten(map(collection, iteratee), 1);
+      return baseFlatten(map(collection, iteratee), 1)
     }
 
     /**
@@ -9295,7 +9463,7 @@
      * // => [1, 1, 2, 2]
      */
     function flatMapDeep(collection, iteratee) {
-      return baseFlatten(map(collection, iteratee), INFINITY);
+      return baseFlatten(map(collection, iteratee), INFINITY)
     }
 
     /**
@@ -9320,8 +9488,8 @@
      * // => [[1, 1], [2, 2]]
      */
     function flatMapDepth(collection, iteratee, depth) {
-      depth = depth === undefined ? 1 : toInteger(depth);
-      return baseFlatten(map(collection, iteratee), depth);
+      depth = depth === undefined ? 1 : toInteger(depth)
+      return baseFlatten(map(collection, iteratee), depth)
     }
 
     /**
@@ -9355,8 +9523,8 @@
      * // => Logs 'a' then 'b' (iteration order is not guaranteed).
      */
     function forEach(collection, iteratee) {
-      var func = isArray(collection) ? arrayEach : baseEach;
-      return func(collection, getIteratee(iteratee, 3));
+      var func = isArray(collection) ? arrayEach : baseEach
+      return func(collection, getIteratee(iteratee, 3))
     }
 
     /**
@@ -9380,8 +9548,8 @@
      * // => Logs `2` then `1`.
      */
     function forEachRight(collection, iteratee) {
-      var func = isArray(collection) ? arrayEachRight : baseEachRight;
-      return func(collection, getIteratee(iteratee, 3));
+      var func = isArray(collection) ? arrayEachRight : baseEachRight
+      return func(collection, getIteratee(iteratee, 3))
     }
 
     /**
@@ -9409,11 +9577,11 @@
      */
     var groupBy = createAggregator(function(result, value, key) {
       if (hasOwnProperty.call(result, key)) {
-        result[key].push(value);
+        result[key].push(value)
       } else {
-        baseAssignValue(result, key, [value]);
+        baseAssignValue(result, key, [value])
       }
-    });
+    })
 
     /**
      * Checks if `value` is in `collection`. If `collection` is a string, it's
@@ -9446,16 +9614,16 @@
      * // => true
      */
     function includes(collection, value, fromIndex, guard) {
-      collection = isArrayLike(collection) ? collection : values(collection);
-      fromIndex = (fromIndex && !guard) ? toInteger(fromIndex) : 0;
+      collection = isArrayLike(collection) ? collection : values(collection)
+      fromIndex = fromIndex && !guard ? toInteger(fromIndex) : 0
 
-      var length = collection.length;
+      var length = collection.length
       if (fromIndex < 0) {
-        fromIndex = nativeMax(length + fromIndex, 0);
+        fromIndex = nativeMax(length + fromIndex, 0)
       }
       return isString(collection)
-        ? (fromIndex <= length && collection.indexOf(value, fromIndex) > -1)
-        : (!!length && baseIndexOf(collection, value, fromIndex) > -1);
+        ? fromIndex <= length && collection.indexOf(value, fromIndex) > -1
+        : !!length && baseIndexOf(collection, value, fromIndex) > -1
     }
 
     /**
@@ -9483,14 +9651,14 @@
      */
     var invokeMap = baseRest(function(collection, path, args) {
       var index = -1,
-          isFunc = typeof path == 'function',
-          result = isArrayLike(collection) ? Array(collection.length) : [];
+        isFunc = typeof path == 'function',
+        result = isArrayLike(collection) ? Array(collection.length) : []
 
       baseEach(collection, function(value) {
-        result[++index] = isFunc ? apply(path, value, args) : baseInvoke(value, path, args);
-      });
-      return result;
-    });
+        result[++index] = isFunc ? apply(path, value, args) : baseInvoke(value, path, args)
+      })
+      return result
+    })
 
     /**
      * Creates an object composed of keys generated from the results of running
@@ -9521,8 +9689,8 @@
      * // => { 'left': { 'dir': 'left', 'code': 97 }, 'right': { 'dir': 'right', 'code': 100 } }
      */
     var keyBy = createAggregator(function(result, value, key) {
-      baseAssignValue(result, key, value);
-    });
+      baseAssignValue(result, key, value)
+    })
 
     /**
      * Creates an array of values by running each element in `collection` thru
@@ -9567,8 +9735,8 @@
      * // => ['barney', 'fred']
      */
     function map(collection, iteratee) {
-      var func = isArray(collection) ? arrayMap : baseMap;
-      return func(collection, getIteratee(iteratee, 3));
+      var func = isArray(collection) ? arrayMap : baseMap
+      return func(collection, getIteratee(iteratee, 3))
     }
 
     /**
@@ -9602,16 +9770,16 @@
      */
     function orderBy(collection, iteratees, orders, guard) {
       if (collection == null) {
-        return [];
+        return []
       }
       if (!isArray(iteratees)) {
-        iteratees = iteratees == null ? [] : [iteratees];
+        iteratees = iteratees == null ? [] : [iteratees]
       }
-      orders = guard ? undefined : orders;
+      orders = guard ? undefined : orders
       if (!isArray(orders)) {
-        orders = orders == null ? [] : [orders];
+        orders = orders == null ? [] : [orders]
       }
-      return baseOrderBy(collection, iteratees, orders);
+      return baseOrderBy(collection, iteratees, orders)
     }
 
     /**
@@ -9650,9 +9818,14 @@
      * _.partition(users, 'active');
      * // => objects for [['fred'], ['barney', 'pebbles']]
      */
-    var partition = createAggregator(function(result, value, key) {
-      result[key ? 0 : 1].push(value);
-    }, function() { return [[], []]; });
+    var partition = createAggregator(
+      function(result, value, key) {
+        result[key ? 0 : 1].push(value)
+      },
+      function() {
+        return [[], []]
+      }
+    )
 
     /**
      * Reduces `collection` to a value which is the accumulated result of running
@@ -9693,9 +9866,9 @@
      */
     function reduce(collection, iteratee, accumulator) {
       var func = isArray(collection) ? arrayReduce : baseReduce,
-          initAccum = arguments.length < 3;
+        initAccum = arguments.length < 3
 
-      return func(collection, getIteratee(iteratee, 4), accumulator, initAccum, baseEach);
+      return func(collection, getIteratee(iteratee, 4), accumulator, initAccum, baseEach)
     }
 
     /**
@@ -9722,9 +9895,9 @@
      */
     function reduceRight(collection, iteratee, accumulator) {
       var func = isArray(collection) ? arrayReduceRight : baseReduce,
-          initAccum = arguments.length < 3;
+        initAccum = arguments.length < 3
 
-      return func(collection, getIteratee(iteratee, 4), accumulator, initAccum, baseEachRight);
+      return func(collection, getIteratee(iteratee, 4), accumulator, initAccum, baseEachRight)
     }
 
     /**
@@ -9762,8 +9935,8 @@
      * // => objects for ['barney']
      */
     function reject(collection, predicate) {
-      var func = isArray(collection) ? arrayFilter : baseFilter;
-      return func(collection, negate(getIteratee(predicate, 3)));
+      var func = isArray(collection) ? arrayFilter : baseFilter
+      return func(collection, negate(getIteratee(predicate, 3)))
     }
 
     /**
@@ -9781,8 +9954,8 @@
      * // => 2
      */
     function sample(collection) {
-      var func = isArray(collection) ? arraySample : baseSample;
-      return func(collection);
+      var func = isArray(collection) ? arraySample : baseSample
+      return func(collection)
     }
 
     /**
@@ -9806,13 +9979,13 @@
      * // => [2, 3, 1]
      */
     function sampleSize(collection, n, guard) {
-      if ((guard ? isIterateeCall(collection, n, guard) : n === undefined)) {
-        n = 1;
+      if (guard ? isIterateeCall(collection, n, guard) : n === undefined) {
+        n = 1
       } else {
-        n = toInteger(n);
+        n = toInteger(n)
       }
-      var func = isArray(collection) ? arraySampleSize : baseSampleSize;
-      return func(collection, n);
+      var func = isArray(collection) ? arraySampleSize : baseSampleSize
+      return func(collection, n)
     }
 
     /**
@@ -9831,8 +10004,8 @@
      * // => [4, 1, 3, 2]
      */
     function shuffle(collection) {
-      var func = isArray(collection) ? arrayShuffle : baseShuffle;
-      return func(collection);
+      var func = isArray(collection) ? arrayShuffle : baseShuffle
+      return func(collection)
     }
 
     /**
@@ -9858,16 +10031,16 @@
      */
     function size(collection) {
       if (collection == null) {
-        return 0;
+        return 0
       }
       if (isArrayLike(collection)) {
-        return isString(collection) ? stringSize(collection) : collection.length;
+        return isString(collection) ? stringSize(collection) : collection.length
       }
-      var tag = getTag(collection);
+      var tag = getTag(collection)
       if (tag == mapTag || tag == setTag) {
-        return collection.size;
+        return collection.size
       }
-      return baseKeys(collection).length;
+      return baseKeys(collection).length
     }
 
     /**
@@ -9907,11 +10080,11 @@
      * // => true
      */
     function some(collection, predicate, guard) {
-      var func = isArray(collection) ? arraySome : baseSome;
+      var func = isArray(collection) ? arraySome : baseSome
       if (guard && isIterateeCall(collection, predicate, guard)) {
-        predicate = undefined;
+        predicate = undefined
       }
-      return func(collection, getIteratee(predicate, 3));
+      return func(collection, getIteratee(predicate, 3))
     }
 
     /**
@@ -9945,16 +10118,16 @@
      */
     var sortBy = baseRest(function(collection, iteratees) {
       if (collection == null) {
-        return [];
+        return []
       }
-      var length = iteratees.length;
+      var length = iteratees.length
       if (length > 1 && isIterateeCall(collection, iteratees[0], iteratees[1])) {
-        iteratees = [];
+        iteratees = []
       } else if (length > 2 && isIterateeCall(iteratees[0], iteratees[1], iteratees[2])) {
-        iteratees = [iteratees[0]];
+        iteratees = [iteratees[0]]
       }
-      return baseOrderBy(collection, baseFlatten(iteratees, 1), []);
-    });
+      return baseOrderBy(collection, baseFlatten(iteratees, 1), [])
+    })
 
     /*------------------------------------------------------------------------*/
 
@@ -9974,9 +10147,11 @@
      * }, _.now());
      * // => Logs the number of milliseconds it took for the deferred invocation.
      */
-    var now = ctxNow || function() {
-      return root.Date.now();
-    };
+    var now =
+      ctxNow ||
+      function() {
+        return root.Date.now()
+      }
 
     /*------------------------------------------------------------------------*/
 
@@ -10006,14 +10181,14 @@
      */
     function after(n, func) {
       if (typeof func != 'function') {
-        throw new TypeError(FUNC_ERROR_TEXT);
+        throw new TypeError(FUNC_ERROR_TEXT)
       }
-      n = toInteger(n);
+      n = toInteger(n)
       return function() {
         if (--n < 1) {
-          return func.apply(this, arguments);
+          return func.apply(this, arguments)
         }
-      };
+      }
     }
 
     /**
@@ -10034,9 +10209,9 @@
      * // => [6, 8, 10]
      */
     function ary(func, n, guard) {
-      n = guard ? undefined : n;
-      n = (func && n == null) ? func.length : n;
-      return createWrap(func, WRAP_ARY_FLAG, undefined, undefined, undefined, undefined, n);
+      n = guard ? undefined : n
+      n = func && n == null ? func.length : n
+      return createWrap(func, WRAP_ARY_FLAG, undefined, undefined, undefined, undefined, n)
     }
 
     /**
@@ -10057,20 +10232,20 @@
      * // => Allows adding up to 4 contacts to the list.
      */
     function before(n, func) {
-      var result;
+      var result
       if (typeof func != 'function') {
-        throw new TypeError(FUNC_ERROR_TEXT);
+        throw new TypeError(FUNC_ERROR_TEXT)
       }
-      n = toInteger(n);
+      n = toInteger(n)
       return function() {
         if (--n > 0) {
-          result = func.apply(this, arguments);
+          result = func.apply(this, arguments)
         }
         if (n <= 1) {
-          func = undefined;
+          func = undefined
         }
-        return result;
-      };
+        return result
+      }
     }
 
     /**
@@ -10109,13 +10284,13 @@
      * // => 'hi fred!'
      */
     var bind = baseRest(function(func, thisArg, partials) {
-      var bitmask = WRAP_BIND_FLAG;
+      var bitmask = WRAP_BIND_FLAG
       if (partials.length) {
-        var holders = replaceHolders(partials, getHolder(bind));
-        bitmask |= WRAP_PARTIAL_FLAG;
+        var holders = replaceHolders(partials, getHolder(bind))
+        bitmask |= WRAP_PARTIAL_FLAG
       }
-      return createWrap(func, bitmask, thisArg, partials, holders);
-    });
+      return createWrap(func, bitmask, thisArg, partials, holders)
+    })
 
     /**
      * Creates a function that invokes the method at `object[key]` with `partials`
@@ -10163,13 +10338,13 @@
      * // => 'hiya fred!'
      */
     var bindKey = baseRest(function(object, key, partials) {
-      var bitmask = WRAP_BIND_FLAG | WRAP_BIND_KEY_FLAG;
+      var bitmask = WRAP_BIND_FLAG | WRAP_BIND_KEY_FLAG
       if (partials.length) {
-        var holders = replaceHolders(partials, getHolder(bindKey));
-        bitmask |= WRAP_PARTIAL_FLAG;
+        var holders = replaceHolders(partials, getHolder(bindKey))
+        bitmask |= WRAP_PARTIAL_FLAG
       }
-      return createWrap(key, bitmask, object, partials, holders);
-    });
+      return createWrap(key, bitmask, object, partials, holders)
+    })
 
     /**
      * Creates a function that accepts arguments of `func` and either invokes
@@ -10213,10 +10388,10 @@
      * // => [1, 2, 3]
      */
     function curry(func, arity, guard) {
-      arity = guard ? undefined : arity;
-      var result = createWrap(func, WRAP_CURRY_FLAG, undefined, undefined, undefined, undefined, undefined, arity);
-      result.placeholder = curry.placeholder;
-      return result;
+      arity = guard ? undefined : arity
+      var result = createWrap(func, WRAP_CURRY_FLAG, undefined, undefined, undefined, undefined, undefined, arity)
+      result.placeholder = curry.placeholder
+      return result
     }
 
     /**
@@ -10258,10 +10433,10 @@
      * // => [1, 2, 3]
      */
     function curryRight(func, arity, guard) {
-      arity = guard ? undefined : arity;
-      var result = createWrap(func, WRAP_CURRY_RIGHT_FLAG, undefined, undefined, undefined, undefined, undefined, arity);
-      result.placeholder = curryRight.placeholder;
-      return result;
+      arity = guard ? undefined : arity
+      var result = createWrap(func, WRAP_CURRY_RIGHT_FLAG, undefined, undefined, undefined, undefined, undefined, arity)
+      result.placeholder = curryRight.placeholder
+      return result
     }
 
     /**
@@ -10320,124 +10495,128 @@
      */
     function debounce(func, wait, options) {
       var lastArgs,
-          lastThis,
-          maxWait,
-          result,
-          timerId,
-          lastCallTime,
-          lastInvokeTime = 0,
-          leading = false,
-          maxing = false,
-          trailing = true;
+        lastThis,
+        maxWait,
+        result,
+        timerId,
+        lastCallTime,
+        lastInvokeTime = 0,
+        leading = false,
+        maxing = false,
+        trailing = true
 
       if (typeof func != 'function') {
-        throw new TypeError(FUNC_ERROR_TEXT);
+        throw new TypeError(FUNC_ERROR_TEXT)
       }
-      wait = toNumber(wait) || 0;
+      wait = toNumber(wait) || 0
       if (isObject(options)) {
-        leading = !!options.leading;
-        maxing = 'maxWait' in options;
-        maxWait = maxing ? nativeMax(toNumber(options.maxWait) || 0, wait) : maxWait;
-        trailing = 'trailing' in options ? !!options.trailing : trailing;
+        leading = !!options.leading
+        maxing = 'maxWait' in options
+        maxWait = maxing ? nativeMax(toNumber(options.maxWait) || 0, wait) : maxWait
+        trailing = 'trailing' in options ? !!options.trailing : trailing
       }
 
       function invokeFunc(time) {
         var args = lastArgs,
-            thisArg = lastThis;
+          thisArg = lastThis
 
-        lastArgs = lastThis = undefined;
-        lastInvokeTime = time;
-        result = func.apply(thisArg, args);
-        return result;
+        lastArgs = lastThis = undefined
+        lastInvokeTime = time
+        result = func.apply(thisArg, args)
+        return result
       }
 
       function leadingEdge(time) {
         // Reset any `maxWait` timer.
-        lastInvokeTime = time;
+        lastInvokeTime = time
         // Start the timer for the trailing edge.
-        timerId = setTimeout(timerExpired, wait);
+        timerId = setTimeout(timerExpired, wait)
         // Invoke the leading edge.
-        return leading ? invokeFunc(time) : result;
+        return leading ? invokeFunc(time) : result
       }
 
       function remainingWait(time) {
         var timeSinceLastCall = time - lastCallTime,
-            timeSinceLastInvoke = time - lastInvokeTime,
-            result = wait - timeSinceLastCall;
+          timeSinceLastInvoke = time - lastInvokeTime,
+          result = wait - timeSinceLastCall
 
-        return maxing ? nativeMin(result, maxWait - timeSinceLastInvoke) : result;
+        return maxing ? nativeMin(result, maxWait - timeSinceLastInvoke) : result
       }
 
       function shouldInvoke(time) {
         var timeSinceLastCall = time - lastCallTime,
-            timeSinceLastInvoke = time - lastInvokeTime;
+          timeSinceLastInvoke = time - lastInvokeTime
 
         // Either this is the first call, activity has stopped and we're at the
         // trailing edge, the system time has gone backwards and we're treating
         // it as the trailing edge, or we've hit the `maxWait` limit.
-        return (lastCallTime === undefined || (timeSinceLastCall >= wait) ||
-          (timeSinceLastCall < 0) || (maxing && timeSinceLastInvoke >= maxWait));
+        return (
+          lastCallTime === undefined ||
+          timeSinceLastCall >= wait ||
+          timeSinceLastCall < 0 ||
+          (maxing && timeSinceLastInvoke >= maxWait)
+        )
       }
 
       function timerExpired() {
-        var time = now();
+        var time = now()
         if (shouldInvoke(time)) {
-          return trailingEdge(time);
+          return trailingEdge(time)
         }
         // Restart the timer.
-        timerId = setTimeout(timerExpired, remainingWait(time));
+        timerId = setTimeout(timerExpired, remainingWait(time))
       }
 
       function trailingEdge(time) {
-        timerId = undefined;
+        timerId = undefined
 
         // Only invoke if we have `lastArgs` which means `func` has been
         // debounced at least once.
         if (trailing && lastArgs) {
-          return invokeFunc(time);
+          return invokeFunc(time)
         }
-        lastArgs = lastThis = undefined;
-        return result;
+        lastArgs = lastThis = undefined
+        return result
       }
 
       function cancel() {
         if (timerId !== undefined) {
-          clearTimeout(timerId);
+          clearTimeout(timerId)
         }
-        lastInvokeTime = 0;
-        lastArgs = lastCallTime = lastThis = timerId = undefined;
+        lastInvokeTime = 0
+        lastArgs = lastCallTime = lastThis = timerId = undefined
       }
 
       function flush() {
-        return timerId === undefined ? result : trailingEdge(now());
+        return timerId === undefined ? result : trailingEdge(now())
       }
 
       function debounced() {
         var time = now(),
-            isInvoking = shouldInvoke(time);
+          isInvoking = shouldInvoke(time)
 
-        lastArgs = arguments;
-        lastThis = this;
-        lastCallTime = time;
+        lastArgs = arguments
+        lastThis = this
+        lastCallTime = time
 
         if (isInvoking) {
           if (timerId === undefined) {
-            return leadingEdge(lastCallTime);
+            return leadingEdge(lastCallTime)
           }
           if (maxing) {
             // Handle invocations in a tight loop.
-            timerId = setTimeout(timerExpired, wait);
-            return invokeFunc(lastCallTime);
+            timerId = setTimeout(timerExpired, wait)
+            return invokeFunc(lastCallTime)
           }
         }
         if (timerId === undefined) {
-          timerId = setTimeout(timerExpired, wait);
+          timerId = setTimeout(timerExpired, wait)
         }
-        return result;
+        return result
       }
-      debounced.cancel = cancel;
-      debounced.flush = flush;
-      return debounced;
+      debounced.cancel = cancel
+      debounced.flush = flush
+      return debounced
     }
 
     /**
@@ -10459,8 +10638,8 @@
      * // => Logs 'deferred' after one millisecond.
      */
     var defer = baseRest(function(func, args) {
-      return baseDelay(func, 1, args);
-    });
+      return baseDelay(func, 1, args)
+    })
 
     /**
      * Invokes `func` after `wait` milliseconds. Any additional arguments are
@@ -10482,8 +10661,8 @@
      * // => Logs 'later' after one second.
      */
     var delay = baseRest(function(func, wait, args) {
-      return baseDelay(func, toNumber(wait) || 0, args);
-    });
+      return baseDelay(func, toNumber(wait) || 0, args)
+    })
 
     /**
      * Creates a function that invokes `func` with arguments reversed.
@@ -10504,7 +10683,7 @@
      * // => ['d', 'c', 'b', 'a']
      */
     function flip(func) {
-      return createWrap(func, WRAP_FLIP_FLAG);
+      return createWrap(func, WRAP_FLIP_FLAG)
     }
 
     /**
@@ -10553,26 +10732,26 @@
      */
     function memoize(func, resolver) {
       if (typeof func != 'function' || (resolver != null && typeof resolver != 'function')) {
-        throw new TypeError(FUNC_ERROR_TEXT);
+        throw new TypeError(FUNC_ERROR_TEXT)
       }
       var memoized = function() {
         var args = arguments,
-            key = resolver ? resolver.apply(this, args) : args[0],
-            cache = memoized.cache;
+          key = resolver ? resolver.apply(this, args) : args[0],
+          cache = memoized.cache
 
         if (cache.has(key)) {
-          return cache.get(key);
+          return cache.get(key)
         }
-        var result = func.apply(this, args);
-        memoized.cache = cache.set(key, result) || cache;
-        return result;
-      };
-      memoized.cache = new (memoize.Cache || MapCache);
-      return memoized;
+        var result = func.apply(this, args)
+        memoized.cache = cache.set(key, result) || cache
+        return result
+      }
+      memoized.cache = new (memoize.Cache || MapCache)()
+      return memoized
     }
 
     // Expose `MapCache`.
-    memoize.Cache = MapCache;
+    memoize.Cache = MapCache
 
     /**
      * Creates a function that negates the result of the predicate `func`. The
@@ -10596,18 +10775,22 @@
      */
     function negate(predicate) {
       if (typeof predicate != 'function') {
-        throw new TypeError(FUNC_ERROR_TEXT);
+        throw new TypeError(FUNC_ERROR_TEXT)
       }
       return function() {
-        var args = arguments;
+        var args = arguments
         switch (args.length) {
-          case 0: return !predicate.call(this);
-          case 1: return !predicate.call(this, args[0]);
-          case 2: return !predicate.call(this, args[0], args[1]);
-          case 3: return !predicate.call(this, args[0], args[1], args[2]);
+          case 0:
+            return !predicate.call(this)
+          case 1:
+            return !predicate.call(this, args[0])
+          case 2:
+            return !predicate.call(this, args[0], args[1])
+          case 3:
+            return !predicate.call(this, args[0], args[1], args[2])
         }
-        return !predicate.apply(this, args);
-      };
+        return !predicate.apply(this, args)
+      }
     }
 
     /**
@@ -10629,7 +10812,7 @@
      * // => `createApplication` is invoked once
      */
     function once(func) {
-      return before(2, func);
+      return before(2, func)
     }
 
     /**
@@ -10664,21 +10847,22 @@
      * // => [100, 10]
      */
     var overArgs = castRest(function(func, transforms) {
-      transforms = (transforms.length == 1 && isArray(transforms[0]))
-        ? arrayMap(transforms[0], baseUnary(getIteratee()))
-        : arrayMap(baseFlatten(transforms, 1), baseUnary(getIteratee()));
+      transforms =
+        transforms.length == 1 && isArray(transforms[0])
+          ? arrayMap(transforms[0], baseUnary(getIteratee()))
+          : arrayMap(baseFlatten(transforms, 1), baseUnary(getIteratee()))
 
-      var funcsLength = transforms.length;
+      var funcsLength = transforms.length
       return baseRest(function(args) {
         var index = -1,
-            length = nativeMin(args.length, funcsLength);
+          length = nativeMin(args.length, funcsLength)
 
         while (++index < length) {
-          args[index] = transforms[index].call(this, args[index]);
+          args[index] = transforms[index].call(this, args[index])
         }
-        return apply(func, this, args);
-      });
-    });
+        return apply(func, this, args)
+      })
+    })
 
     /**
      * Creates a function that invokes `func` with `partials` prepended to the
@@ -10714,9 +10898,9 @@
      * // => 'hi fred'
      */
     var partial = baseRest(function(func, partials) {
-      var holders = replaceHolders(partials, getHolder(partial));
-      return createWrap(func, WRAP_PARTIAL_FLAG, undefined, partials, holders);
-    });
+      var holders = replaceHolders(partials, getHolder(partial))
+      return createWrap(func, WRAP_PARTIAL_FLAG, undefined, partials, holders)
+    })
 
     /**
      * This method is like `_.partial` except that partially applied arguments
@@ -10751,9 +10935,9 @@
      * // => 'hello fred'
      */
     var partialRight = baseRest(function(func, partials) {
-      var holders = replaceHolders(partials, getHolder(partialRight));
-      return createWrap(func, WRAP_PARTIAL_RIGHT_FLAG, undefined, partials, holders);
-    });
+      var holders = replaceHolders(partials, getHolder(partialRight))
+      return createWrap(func, WRAP_PARTIAL_RIGHT_FLAG, undefined, partials, holders)
+    })
 
     /**
      * Creates a function that invokes `func` with arguments arranged according
@@ -10778,8 +10962,8 @@
      * // => ['a', 'b', 'c']
      */
     var rearg = flatRest(function(func, indexes) {
-      return createWrap(func, WRAP_REARG_FLAG, undefined, undefined, undefined, indexes);
-    });
+      return createWrap(func, WRAP_REARG_FLAG, undefined, undefined, undefined, indexes)
+    })
 
     /**
      * Creates a function that invokes `func` with the `this` binding of the
@@ -10808,10 +10992,10 @@
      */
     function rest(func, start) {
       if (typeof func != 'function') {
-        throw new TypeError(FUNC_ERROR_TEXT);
+        throw new TypeError(FUNC_ERROR_TEXT)
       }
-      start = start === undefined ? start : toInteger(start);
-      return baseRest(func, start);
+      start = start === undefined ? start : toInteger(start)
+      return baseRest(func, start)
     }
 
     /**
@@ -10850,18 +11034,18 @@
      */
     function spread(func, start) {
       if (typeof func != 'function') {
-        throw new TypeError(FUNC_ERROR_TEXT);
+        throw new TypeError(FUNC_ERROR_TEXT)
       }
-      start = start == null ? 0 : nativeMax(toInteger(start), 0);
+      start = start == null ? 0 : nativeMax(toInteger(start), 0)
       return baseRest(function(args) {
         var array = args[start],
-            otherArgs = castSlice(args, 0, start);
+          otherArgs = castSlice(args, 0, start)
 
         if (array) {
-          arrayPush(otherArgs, array);
+          arrayPush(otherArgs, array)
         }
-        return apply(func, this, otherArgs);
-      });
+        return apply(func, this, otherArgs)
+      })
     }
 
     /**
@@ -10910,20 +11094,20 @@
      */
     function throttle(func, wait, options) {
       var leading = true,
-          trailing = true;
+        trailing = true
 
       if (typeof func != 'function') {
-        throw new TypeError(FUNC_ERROR_TEXT);
+        throw new TypeError(FUNC_ERROR_TEXT)
       }
       if (isObject(options)) {
-        leading = 'leading' in options ? !!options.leading : leading;
-        trailing = 'trailing' in options ? !!options.trailing : trailing;
+        leading = 'leading' in options ? !!options.leading : leading
+        trailing = 'trailing' in options ? !!options.trailing : trailing
       }
       return debounce(func, wait, {
-        'leading': leading,
-        'maxWait': wait,
-        'trailing': trailing
-      });
+        leading: leading,
+        maxWait: wait,
+        trailing: trailing
+      })
     }
 
     /**
@@ -10942,7 +11126,7 @@
      * // => [6, 8, 10]
      */
     function unary(func) {
-      return ary(func, 1);
+      return ary(func, 1)
     }
 
     /**
@@ -10968,7 +11152,7 @@
      * // => '<p>fred, barney, &amp; pebbles</p>'
      */
     function wrap(value, wrapper) {
-      return partial(castFunction(wrapper), value);
+      return partial(castFunction(wrapper), value)
     }
 
     /*------------------------------------------------------------------------*/
@@ -11008,10 +11192,10 @@
      */
     function castArray() {
       if (!arguments.length) {
-        return [];
+        return []
       }
-      var value = arguments[0];
-      return isArray(value) ? value : [value];
+      var value = arguments[0]
+      return isArray(value) ? value : [value]
     }
 
     /**
@@ -11041,7 +11225,7 @@
      * // => true
      */
     function clone(value) {
-      return baseClone(value, CLONE_SYMBOLS_FLAG);
+      return baseClone(value, CLONE_SYMBOLS_FLAG)
     }
 
     /**
@@ -11076,8 +11260,8 @@
      * // => 0
      */
     function cloneWith(value, customizer) {
-      customizer = typeof customizer == 'function' ? customizer : undefined;
-      return baseClone(value, CLONE_SYMBOLS_FLAG, customizer);
+      customizer = typeof customizer == 'function' ? customizer : undefined
+      return baseClone(value, CLONE_SYMBOLS_FLAG, customizer)
     }
 
     /**
@@ -11099,7 +11283,7 @@
      * // => false
      */
     function cloneDeep(value) {
-      return baseClone(value, CLONE_DEEP_FLAG | CLONE_SYMBOLS_FLAG);
+      return baseClone(value, CLONE_DEEP_FLAG | CLONE_SYMBOLS_FLAG)
     }
 
     /**
@@ -11131,8 +11315,8 @@
      * // => 20
      */
     function cloneDeepWith(value, customizer) {
-      customizer = typeof customizer == 'function' ? customizer : undefined;
-      return baseClone(value, CLONE_DEEP_FLAG | CLONE_SYMBOLS_FLAG, customizer);
+      customizer = typeof customizer == 'function' ? customizer : undefined
+      return baseClone(value, CLONE_DEEP_FLAG | CLONE_SYMBOLS_FLAG, customizer)
     }
 
     /**
@@ -11160,7 +11344,7 @@
      * // => false
      */
     function conformsTo(object, source) {
-      return source == null || baseConformsTo(object, source, keys(source));
+      return source == null || baseConformsTo(object, source, keys(source))
     }
 
     /**
@@ -11196,7 +11380,7 @@
      * // => true
      */
     function eq(value, other) {
-      return value === other || (value !== value && other !== other);
+      return value === other || (value !== value && other !== other)
     }
 
     /**
@@ -11222,7 +11406,7 @@
      * _.gt(1, 3);
      * // => false
      */
-    var gt = createRelationalOperation(baseGt);
+    var gt = createRelationalOperation(baseGt)
 
     /**
      * Checks if `value` is greater than or equal to `other`.
@@ -11248,8 +11432,8 @@
      * // => false
      */
     var gte = createRelationalOperation(function(value, other) {
-      return value >= other;
-    });
+      return value >= other
+    })
 
     /**
      * Checks if `value` is likely an `arguments` object.
@@ -11269,10 +11453,17 @@
      * _.isArguments([1, 2, 3]);
      * // => false
      */
-    var isArguments = baseIsArguments(function() { return arguments; }()) ? baseIsArguments : function(value) {
-      return isObjectLike(value) && hasOwnProperty.call(value, 'callee') &&
-        !propertyIsEnumerable.call(value, 'callee');
-    };
+    var isArguments = baseIsArguments(
+      (function() {
+        return arguments
+      })()
+    )
+      ? baseIsArguments
+      : function(value) {
+          return (
+            isObjectLike(value) && hasOwnProperty.call(value, 'callee') && !propertyIsEnumerable.call(value, 'callee')
+          )
+        }
 
     /**
      * Checks if `value` is classified as an `Array` object.
@@ -11297,7 +11488,7 @@
      * _.isArray(_.noop);
      * // => false
      */
-    var isArray = Array.isArray;
+    var isArray = Array.isArray
 
     /**
      * Checks if `value` is classified as an `ArrayBuffer` object.
@@ -11316,7 +11507,7 @@
      * _.isArrayBuffer(new Array(2));
      * // => false
      */
-    var isArrayBuffer = nodeIsArrayBuffer ? baseUnary(nodeIsArrayBuffer) : baseIsArrayBuffer;
+    var isArrayBuffer = nodeIsArrayBuffer ? baseUnary(nodeIsArrayBuffer) : baseIsArrayBuffer
 
     /**
      * Checks if `value` is array-like. A value is considered array-like if it's
@@ -11344,7 +11535,7 @@
      * // => false
      */
     function isArrayLike(value) {
-      return value != null && isLength(value.length) && !isFunction(value);
+      return value != null && isLength(value.length) && !isFunction(value)
     }
 
     /**
@@ -11373,7 +11564,7 @@
      * // => false
      */
     function isArrayLikeObject(value) {
-      return isObjectLike(value) && isArrayLike(value);
+      return isObjectLike(value) && isArrayLike(value)
     }
 
     /**
@@ -11394,8 +11585,7 @@
      * // => false
      */
     function isBoolean(value) {
-      return value === true || value === false ||
-        (isObjectLike(value) && baseGetTag(value) == boolTag);
+      return value === true || value === false || (isObjectLike(value) && baseGetTag(value) == boolTag)
     }
 
     /**
@@ -11415,7 +11605,7 @@
      * _.isBuffer(new Uint8Array(2));
      * // => false
      */
-    var isBuffer = nativeIsBuffer || stubFalse;
+    var isBuffer = nativeIsBuffer || stubFalse
 
     /**
      * Checks if `value` is classified as a `Date` object.
@@ -11434,7 +11624,7 @@
      * _.isDate('Mon April 23 2012');
      * // => false
      */
-    var isDate = nodeIsDate ? baseUnary(nodeIsDate) : baseIsDate;
+    var isDate = nodeIsDate ? baseUnary(nodeIsDate) : baseIsDate
 
     /**
      * Checks if `value` is likely a DOM element.
@@ -11454,7 +11644,7 @@
      * // => false
      */
     function isElement(value) {
-      return isObjectLike(value) && value.nodeType === 1 && !isPlainObject(value);
+      return isObjectLike(value) && value.nodeType === 1 && !isPlainObject(value)
     }
 
     /**
@@ -11492,26 +11682,32 @@
      */
     function isEmpty(value) {
       if (value == null) {
-        return true;
+        return true
       }
-      if (isArrayLike(value) &&
-          (isArray(value) || typeof value == 'string' || typeof value.splice == 'function' ||
-            isBuffer(value) || isTypedArray(value) || isArguments(value))) {
-        return !value.length;
+      if (
+        isArrayLike(value) &&
+        (isArray(value) ||
+          typeof value == 'string' ||
+          typeof value.splice == 'function' ||
+          isBuffer(value) ||
+          isTypedArray(value) ||
+          isArguments(value))
+      ) {
+        return !value.length
       }
-      var tag = getTag(value);
+      var tag = getTag(value)
       if (tag == mapTag || tag == setTag) {
-        return !value.size;
+        return !value.size
       }
       if (isPrototype(value)) {
-        return !baseKeys(value).length;
+        return !baseKeys(value).length
       }
       for (var key in value) {
         if (hasOwnProperty.call(value, key)) {
-          return false;
+          return false
         }
       }
-      return true;
+      return true
     }
 
     /**
@@ -11543,7 +11739,7 @@
      * // => false
      */
     function isEqual(value, other) {
-      return baseIsEqual(value, other);
+      return baseIsEqual(value, other)
     }
 
     /**
@@ -11579,9 +11775,9 @@
      * // => true
      */
     function isEqualWith(value, other, customizer) {
-      customizer = typeof customizer == 'function' ? customizer : undefined;
-      var result = customizer ? customizer(value, other) : undefined;
-      return result === undefined ? baseIsEqual(value, other, undefined, customizer) : !!result;
+      customizer = typeof customizer == 'function' ? customizer : undefined
+      var result = customizer ? customizer(value, other) : undefined
+      return result === undefined ? baseIsEqual(value, other, undefined, customizer) : !!result
     }
 
     /**
@@ -11604,11 +11800,14 @@
      */
     function isError(value) {
       if (!isObjectLike(value)) {
-        return false;
+        return false
       }
-      var tag = baseGetTag(value);
-      return tag == errorTag || tag == domExcTag ||
-        (typeof value.message == 'string' && typeof value.name == 'string' && !isPlainObject(value));
+      var tag = baseGetTag(value)
+      return (
+        tag == errorTag ||
+        tag == domExcTag ||
+        (typeof value.message == 'string' && typeof value.name == 'string' && !isPlainObject(value))
+      )
     }
 
     /**
@@ -11638,7 +11837,7 @@
      * // => false
      */
     function isFinite(value) {
-      return typeof value == 'number' && nativeIsFinite(value);
+      return typeof value == 'number' && nativeIsFinite(value)
     }
 
     /**
@@ -11660,12 +11859,12 @@
      */
     function isFunction(value) {
       if (!isObject(value)) {
-        return false;
+        return false
       }
       // The use of `Object#toString` avoids issues with the `typeof` operator
       // in Safari 9 which returns 'object' for typed arrays and other constructors.
-      var tag = baseGetTag(value);
-      return tag == funcTag || tag == genTag || tag == asyncTag || tag == proxyTag;
+      var tag = baseGetTag(value)
+      return tag == funcTag || tag == genTag || tag == asyncTag || tag == proxyTag
     }
 
     /**
@@ -11695,7 +11894,7 @@
      * // => false
      */
     function isInteger(value) {
-      return typeof value == 'number' && value == toInteger(value);
+      return typeof value == 'number' && value == toInteger(value)
     }
 
     /**
@@ -11725,8 +11924,7 @@
      * // => false
      */
     function isLength(value) {
-      return typeof value == 'number' &&
-        value > -1 && value % 1 == 0 && value <= MAX_SAFE_INTEGER;
+      return typeof value == 'number' && value > -1 && value % 1 == 0 && value <= MAX_SAFE_INTEGER
     }
 
     /**
@@ -11755,8 +11953,8 @@
      * // => false
      */
     function isObject(value) {
-      var type = typeof value;
-      return value != null && (type == 'object' || type == 'function');
+      var type = typeof value
+      return value != null && (type == 'object' || type == 'function')
     }
 
     /**
@@ -11784,7 +11982,7 @@
      * // => false
      */
     function isObjectLike(value) {
-      return value != null && typeof value == 'object';
+      return value != null && typeof value == 'object'
     }
 
     /**
@@ -11804,7 +12002,7 @@
      * _.isMap(new WeakMap);
      * // => false
      */
-    var isMap = nodeIsMap ? baseUnary(nodeIsMap) : baseIsMap;
+    var isMap = nodeIsMap ? baseUnary(nodeIsMap) : baseIsMap
 
     /**
      * Performs a partial deep comparison between `object` and `source` to
@@ -11835,7 +12033,7 @@
      * // => false
      */
     function isMatch(object, source) {
-      return object === source || baseIsMatch(object, source, getMatchData(source));
+      return object === source || baseIsMatch(object, source, getMatchData(source))
     }
 
     /**
@@ -11871,8 +12069,8 @@
      * // => true
      */
     function isMatchWith(object, source, customizer) {
-      customizer = typeof customizer == 'function' ? customizer : undefined;
-      return baseIsMatch(object, source, getMatchData(source), customizer);
+      customizer = typeof customizer == 'function' ? customizer : undefined
+      return baseIsMatch(object, source, getMatchData(source), customizer)
     }
 
     /**
@@ -11907,7 +12105,7 @@
       // An `NaN` primitive is the only value that is not equal to itself.
       // Perform the `toStringTag` check first to avoid errors with some
       // ActiveX objects in IE.
-      return isNumber(value) && value != +value;
+      return isNumber(value) && value != +value
     }
 
     /**
@@ -11938,9 +12136,9 @@
      */
     function isNative(value) {
       if (isMaskable(value)) {
-        throw new Error(CORE_ERROR_TEXT);
+        throw new Error(CORE_ERROR_TEXT)
       }
-      return baseIsNative(value);
+      return baseIsNative(value)
     }
 
     /**
@@ -11961,7 +12159,7 @@
      * // => false
      */
     function isNull(value) {
-      return value === null;
+      return value === null
     }
 
     /**
@@ -11985,7 +12183,7 @@
      * // => false
      */
     function isNil(value) {
-      return value == null;
+      return value == null
     }
 
     /**
@@ -12015,8 +12213,7 @@
      * // => false
      */
     function isNumber(value) {
-      return typeof value == 'number' ||
-        (isObjectLike(value) && baseGetTag(value) == numberTag);
+      return typeof value == 'number' || (isObjectLike(value) && baseGetTag(value) == numberTag)
     }
 
     /**
@@ -12049,15 +12246,14 @@
      */
     function isPlainObject(value) {
       if (!isObjectLike(value) || baseGetTag(value) != objectTag) {
-        return false;
+        return false
       }
-      var proto = getPrototype(value);
+      var proto = getPrototype(value)
       if (proto === null) {
-        return true;
+        return true
       }
-      var Ctor = hasOwnProperty.call(proto, 'constructor') && proto.constructor;
-      return typeof Ctor == 'function' && Ctor instanceof Ctor &&
-        funcToString.call(Ctor) == objectCtorString;
+      var Ctor = hasOwnProperty.call(proto, 'constructor') && proto.constructor
+      return typeof Ctor == 'function' && Ctor instanceof Ctor && funcToString.call(Ctor) == objectCtorString
     }
 
     /**
@@ -12077,7 +12273,7 @@
      * _.isRegExp('/abc/');
      * // => false
      */
-    var isRegExp = nodeIsRegExp ? baseUnary(nodeIsRegExp) : baseIsRegExp;
+    var isRegExp = nodeIsRegExp ? baseUnary(nodeIsRegExp) : baseIsRegExp
 
     /**
      * Checks if `value` is a safe integer. An integer is safe if it's an IEEE-754
@@ -12107,7 +12303,7 @@
      * // => false
      */
     function isSafeInteger(value) {
-      return isInteger(value) && value >= -MAX_SAFE_INTEGER && value <= MAX_SAFE_INTEGER;
+      return isInteger(value) && value >= -MAX_SAFE_INTEGER && value <= MAX_SAFE_INTEGER
     }
 
     /**
@@ -12127,7 +12323,7 @@
      * _.isSet(new WeakSet);
      * // => false
      */
-    var isSet = nodeIsSet ? baseUnary(nodeIsSet) : baseIsSet;
+    var isSet = nodeIsSet ? baseUnary(nodeIsSet) : baseIsSet
 
     /**
      * Checks if `value` is classified as a `String` primitive or object.
@@ -12147,8 +12343,7 @@
      * // => false
      */
     function isString(value) {
-      return typeof value == 'string' ||
-        (!isArray(value) && isObjectLike(value) && baseGetTag(value) == stringTag);
+      return typeof value == 'string' || (!isArray(value) && isObjectLike(value) && baseGetTag(value) == stringTag)
     }
 
     /**
@@ -12169,8 +12364,7 @@
      * // => false
      */
     function isSymbol(value) {
-      return typeof value == 'symbol' ||
-        (isObjectLike(value) && baseGetTag(value) == symbolTag);
+      return typeof value == 'symbol' || (isObjectLike(value) && baseGetTag(value) == symbolTag)
     }
 
     /**
@@ -12190,7 +12384,7 @@
      * _.isTypedArray([]);
      * // => false
      */
-    var isTypedArray = nodeIsTypedArray ? baseUnary(nodeIsTypedArray) : baseIsTypedArray;
+    var isTypedArray = nodeIsTypedArray ? baseUnary(nodeIsTypedArray) : baseIsTypedArray
 
     /**
      * Checks if `value` is `undefined`.
@@ -12210,7 +12404,7 @@
      * // => false
      */
     function isUndefined(value) {
-      return value === undefined;
+      return value === undefined
     }
 
     /**
@@ -12231,7 +12425,7 @@
      * // => false
      */
     function isWeakMap(value) {
-      return isObjectLike(value) && getTag(value) == weakMapTag;
+      return isObjectLike(value) && getTag(value) == weakMapTag
     }
 
     /**
@@ -12252,7 +12446,7 @@
      * // => false
      */
     function isWeakSet(value) {
-      return isObjectLike(value) && baseGetTag(value) == weakSetTag;
+      return isObjectLike(value) && baseGetTag(value) == weakSetTag
     }
 
     /**
@@ -12278,7 +12472,7 @@
      * _.lt(3, 1);
      * // => false
      */
-    var lt = createRelationalOperation(baseLt);
+    var lt = createRelationalOperation(baseLt)
 
     /**
      * Checks if `value` is less than or equal to `other`.
@@ -12304,8 +12498,8 @@
      * // => false
      */
     var lte = createRelationalOperation(function(value, other) {
-      return value <= other;
-    });
+      return value <= other
+    })
 
     /**
      * Converts `value` to an array.
@@ -12332,18 +12526,18 @@
      */
     function toArray(value) {
       if (!value) {
-        return [];
+        return []
       }
       if (isArrayLike(value)) {
-        return isString(value) ? stringToArray(value) : copyArray(value);
+        return isString(value) ? stringToArray(value) : copyArray(value)
       }
       if (symIterator && value[symIterator]) {
-        return iteratorToArray(value[symIterator]());
+        return iteratorToArray(value[symIterator]())
       }
       var tag = getTag(value),
-          func = tag == mapTag ? mapToArray : (tag == setTag ? setToArray : values);
+        func = tag == mapTag ? mapToArray : tag == setTag ? setToArray : values
 
-      return func(value);
+      return func(value)
     }
 
     /**
@@ -12371,14 +12565,14 @@
      */
     function toFinite(value) {
       if (!value) {
-        return value === 0 ? value : 0;
+        return value === 0 ? value : 0
       }
-      value = toNumber(value);
+      value = toNumber(value)
       if (value === INFINITY || value === -INFINITY) {
-        var sign = (value < 0 ? -1 : 1);
-        return sign * MAX_INTEGER;
+        var sign = value < 0 ? -1 : 1
+        return sign * MAX_INTEGER
       }
-      return value === value ? value : 0;
+      return value === value ? value : 0
     }
 
     /**
@@ -12409,9 +12603,9 @@
      */
     function toInteger(value) {
       var result = toFinite(value),
-          remainder = result % 1;
+        remainder = result % 1
 
-      return result === result ? (remainder ? result - remainder : result) : 0;
+      return result === result ? (remainder ? result - remainder : result) : 0
     }
 
     /**
@@ -12442,7 +12636,7 @@
      * // => 3
      */
     function toLength(value) {
-      return value ? baseClamp(toInteger(value), 0, MAX_ARRAY_LENGTH) : 0;
+      return value ? baseClamp(toInteger(value), 0, MAX_ARRAY_LENGTH) : 0
     }
 
     /**
@@ -12470,23 +12664,25 @@
      */
     function toNumber(value) {
       if (typeof value == 'number') {
-        return value;
+        return value
       }
       if (isSymbol(value)) {
-        return NAN;
+        return NAN
       }
       if (isObject(value)) {
-        var other = typeof value.valueOf == 'function' ? value.valueOf() : value;
-        value = isObject(other) ? (other + '') : other;
+        var other = typeof value.valueOf == 'function' ? value.valueOf() : value
+        value = isObject(other) ? other + '' : other
       }
       if (typeof value != 'string') {
-        return value === 0 ? value : +value;
+        return value === 0 ? value : +value
       }
-      value = value.replace(reTrim, '');
-      var isBinary = reIsBinary.test(value);
-      return (isBinary || reIsOctal.test(value))
+      value = value.replace(reTrim, '')
+      var isBinary = reIsBinary.test(value)
+      return isBinary || reIsOctal.test(value)
         ? freeParseInt(value.slice(2), isBinary ? 2 : 8)
-        : (reIsBadHex.test(value) ? NAN : +value);
+        : reIsBadHex.test(value)
+          ? NAN
+          : +value
     }
 
     /**
@@ -12514,7 +12710,7 @@
      * // => { 'a': 1, 'b': 2, 'c': 3 }
      */
     function toPlainObject(value) {
-      return copyObject(value, keysIn(value));
+      return copyObject(value, keysIn(value))
     }
 
     /**
@@ -12542,9 +12738,7 @@
      * // => 3
      */
     function toSafeInteger(value) {
-      return value
-        ? baseClamp(toInteger(value), -MAX_SAFE_INTEGER, MAX_SAFE_INTEGER)
-        : (value === 0 ? value : 0);
+      return value ? baseClamp(toInteger(value), -MAX_SAFE_INTEGER, MAX_SAFE_INTEGER) : value === 0 ? value : 0
     }
 
     /**
@@ -12569,7 +12763,7 @@
      * // => '1,2,3'
      */
     function toString(value) {
-      return value == null ? '' : baseToString(value);
+      return value == null ? '' : baseToString(value)
     }
 
     /*------------------------------------------------------------------------*/
@@ -12608,15 +12802,15 @@
      */
     var assign = createAssigner(function(object, source) {
       if (isPrototype(source) || isArrayLike(source)) {
-        copyObject(source, keys(source), object);
-        return;
+        copyObject(source, keys(source), object)
+        return
       }
       for (var key in source) {
         if (hasOwnProperty.call(source, key)) {
-          assignValue(object, key, source[key]);
+          assignValue(object, key, source[key])
         }
       }
-    });
+    })
 
     /**
      * This method is like `_.assign` except that it iterates over own and
@@ -12650,8 +12844,8 @@
      * // => { 'a': 1, 'b': 2, 'c': 3, 'd': 4 }
      */
     var assignIn = createAssigner(function(object, source) {
-      copyObject(source, keysIn(source), object);
-    });
+      copyObject(source, keysIn(source), object)
+    })
 
     /**
      * This method is like `_.assignIn` except that it accepts `customizer`
@@ -12683,8 +12877,8 @@
      * // => { 'a': 1, 'b': 2 }
      */
     var assignInWith = createAssigner(function(object, source, srcIndex, customizer) {
-      copyObject(source, keysIn(source), object, customizer);
-    });
+      copyObject(source, keysIn(source), object, customizer)
+    })
 
     /**
      * This method is like `_.assign` except that it accepts `customizer`
@@ -12715,8 +12909,8 @@
      * // => { 'a': 1, 'b': 2 }
      */
     var assignWith = createAssigner(function(object, source, srcIndex, customizer) {
-      copyObject(source, keys(source), object, customizer);
-    });
+      copyObject(source, keys(source), object, customizer)
+    })
 
     /**
      * Creates an array of values corresponding to `paths` of `object`.
@@ -12735,7 +12929,7 @@
      * _.at(object, ['a[0].b.c', 'a[1]']);
      * // => [3, 4]
      */
-    var at = flatRest(baseAt);
+    var at = flatRest(baseAt)
 
     /**
      * Creates an object that inherits from the `prototype` object. If a
@@ -12772,8 +12966,8 @@
      * // => true
      */
     function create(prototype, properties) {
-      var result = baseCreate(prototype);
-      return properties == null ? result : baseAssign(result, properties);
+      var result = baseCreate(prototype)
+      return properties == null ? result : baseAssign(result, properties)
     }
 
     /**
@@ -12798,9 +12992,9 @@
      * // => { 'a': 1, 'b': 2 }
      */
     var defaults = baseRest(function(args) {
-      args.push(undefined, customDefaultsAssignIn);
-      return apply(assignInWith, undefined, args);
-    });
+      args.push(undefined, customDefaultsAssignIn)
+      return apply(assignInWith, undefined, args)
+    })
 
     /**
      * This method is like `_.defaults` except that it recursively assigns
@@ -12822,9 +13016,9 @@
      * // => { 'a': { 'b': 2, 'c': 3 } }
      */
     var defaultsDeep = baseRest(function(args) {
-      args.push(undefined, customDefaultsMerge);
-      return apply(mergeWith, undefined, args);
-    });
+      args.push(undefined, customDefaultsMerge)
+      return apply(mergeWith, undefined, args)
+    })
 
     /**
      * This method is like `_.find` except that it returns the key of the first
@@ -12862,7 +13056,7 @@
      * // => 'barney'
      */
     function findKey(object, predicate) {
-      return baseFindKey(object, getIteratee(predicate, 3), baseForOwn);
+      return baseFindKey(object, getIteratee(predicate, 3), baseForOwn)
     }
 
     /**
@@ -12901,7 +13095,7 @@
      * // => 'pebbles'
      */
     function findLastKey(object, predicate) {
-      return baseFindKey(object, getIteratee(predicate, 3), baseForOwnRight);
+      return baseFindKey(object, getIteratee(predicate, 3), baseForOwnRight)
     }
 
     /**
@@ -12933,9 +13127,7 @@
      * // => Logs 'a', 'b', then 'c' (iteration order is not guaranteed).
      */
     function forIn(object, iteratee) {
-      return object == null
-        ? object
-        : baseFor(object, getIteratee(iteratee, 3), keysIn);
+      return object == null ? object : baseFor(object, getIteratee(iteratee, 3), keysIn)
     }
 
     /**
@@ -12965,9 +13157,7 @@
      * // => Logs 'c', 'b', then 'a' assuming `_.forIn` logs 'a', 'b', then 'c'.
      */
     function forInRight(object, iteratee) {
-      return object == null
-        ? object
-        : baseForRight(object, getIteratee(iteratee, 3), keysIn);
+      return object == null ? object : baseForRight(object, getIteratee(iteratee, 3), keysIn)
     }
 
     /**
@@ -12999,7 +13189,7 @@
      * // => Logs 'a' then 'b' (iteration order is not guaranteed).
      */
     function forOwn(object, iteratee) {
-      return object && baseForOwn(object, getIteratee(iteratee, 3));
+      return object && baseForOwn(object, getIteratee(iteratee, 3))
     }
 
     /**
@@ -13029,7 +13219,7 @@
      * // => Logs 'b' then 'a' assuming `_.forOwn` logs 'a' then 'b'.
      */
     function forOwnRight(object, iteratee) {
-      return object && baseForOwnRight(object, getIteratee(iteratee, 3));
+      return object && baseForOwnRight(object, getIteratee(iteratee, 3))
     }
 
     /**
@@ -13056,7 +13246,7 @@
      * // => ['a', 'b']
      */
     function functions(object) {
-      return object == null ? [] : baseFunctions(object, keys(object));
+      return object == null ? [] : baseFunctions(object, keys(object))
     }
 
     /**
@@ -13083,7 +13273,7 @@
      * // => ['a', 'b', 'c']
      */
     function functionsIn(object) {
-      return object == null ? [] : baseFunctions(object, keysIn(object));
+      return object == null ? [] : baseFunctions(object, keysIn(object))
     }
 
     /**
@@ -13112,8 +13302,8 @@
      * // => 'default'
      */
     function get(object, path, defaultValue) {
-      var result = object == null ? undefined : baseGet(object, path);
-      return result === undefined ? defaultValue : result;
+      var result = object == null ? undefined : baseGet(object, path)
+      return result === undefined ? defaultValue : result
     }
 
     /**
@@ -13144,7 +13334,7 @@
      * // => false
      */
     function has(object, path) {
-      return object != null && hasPath(object, path, baseHas);
+      return object != null && hasPath(object, path, baseHas)
     }
 
     /**
@@ -13174,7 +13364,7 @@
      * // => false
      */
     function hasIn(object, path) {
-      return object != null && hasPath(object, path, baseHasIn);
+      return object != null && hasPath(object, path, baseHasIn)
     }
 
     /**
@@ -13196,8 +13386,8 @@
      * // => { '1': 'c', '2': 'b' }
      */
     var invert = createInverter(function(result, value, key) {
-      result[value] = key;
-    }, constant(identity));
+      result[value] = key
+    }, constant(identity))
 
     /**
      * This method is like `_.invert` except that the inverted object is generated
@@ -13227,11 +13417,11 @@
      */
     var invertBy = createInverter(function(result, value, key) {
       if (hasOwnProperty.call(result, value)) {
-        result[value].push(key);
+        result[value].push(key)
       } else {
-        result[value] = [key];
+        result[value] = [key]
       }
-    }, getIteratee);
+    }, getIteratee)
 
     /**
      * Invokes the method at `path` of `object`.
@@ -13251,7 +13441,7 @@
      * _.invoke(object, 'a[0].b.c.slice', 1, 3);
      * // => [2, 3]
      */
-    var invoke = baseRest(baseInvoke);
+    var invoke = baseRest(baseInvoke)
 
     /**
      * Creates an array of the own enumerable property names of `object`.
@@ -13282,7 +13472,7 @@
      * // => ['0', '1']
      */
     function keys(object) {
-      return isArrayLike(object) ? arrayLikeKeys(object) : baseKeys(object);
+      return isArrayLike(object) ? arrayLikeKeys(object) : baseKeys(object)
     }
 
     /**
@@ -13309,7 +13499,7 @@
      * // => ['a', 'b', 'c'] (iteration order is not guaranteed)
      */
     function keysIn(object) {
-      return isArrayLike(object) ? arrayLikeKeys(object, true) : baseKeysIn(object);
+      return isArrayLike(object) ? arrayLikeKeys(object, true) : baseKeysIn(object)
     }
 
     /**
@@ -13334,13 +13524,13 @@
      * // => { 'a1': 1, 'b2': 2 }
      */
     function mapKeys(object, iteratee) {
-      var result = {};
-      iteratee = getIteratee(iteratee, 3);
+      var result = {}
+      iteratee = getIteratee(iteratee, 3)
 
       baseForOwn(object, function(value, key, object) {
-        baseAssignValue(result, iteratee(value, key, object), value);
-      });
-      return result;
+        baseAssignValue(result, iteratee(value, key, object), value)
+      })
+      return result
     }
 
     /**
@@ -13372,13 +13562,13 @@
      * // => { 'fred': 40, 'pebbles': 1 } (iteration order is not guaranteed)
      */
     function mapValues(object, iteratee) {
-      var result = {};
-      iteratee = getIteratee(iteratee, 3);
+      var result = {}
+      iteratee = getIteratee(iteratee, 3)
 
       baseForOwn(object, function(value, key, object) {
-        baseAssignValue(result, key, iteratee(value, key, object));
-      });
-      return result;
+        baseAssignValue(result, key, iteratee(value, key, object))
+      })
+      return result
     }
 
     /**
@@ -13413,8 +13603,8 @@
      * // => { 'a': [{ 'b': 2, 'c': 3 }, { 'd': 4, 'e': 5 }] }
      */
     var merge = createAssigner(function(object, source, srcIndex) {
-      baseMerge(object, source, srcIndex);
-    });
+      baseMerge(object, source, srcIndex)
+    })
 
     /**
      * This method is like `_.merge` except that it accepts `customizer` which
@@ -13448,8 +13638,8 @@
      * // => { 'a': [1, 3], 'b': [2, 4] }
      */
     var mergeWith = createAssigner(function(object, source, srcIndex, customizer) {
-      baseMerge(object, source, srcIndex, customizer);
-    });
+      baseMerge(object, source, srcIndex, customizer)
+    })
 
     /**
      * The opposite of `_.pick`; this method creates an object composed of the
@@ -13472,26 +13662,26 @@
      * // => { 'b': '2' }
      */
     var omit = flatRest(function(object, paths) {
-      var result = {};
+      var result = {}
       if (object == null) {
-        return result;
+        return result
       }
-      var isDeep = false;
+      var isDeep = false
       paths = arrayMap(paths, function(path) {
-        path = castPath(path, object);
-        isDeep || (isDeep = path.length > 1);
-        return path;
-      });
-      copyObject(object, getAllKeysIn(object), result);
+        path = castPath(path, object)
+        isDeep || (isDeep = path.length > 1)
+        return path
+      })
+      copyObject(object, getAllKeysIn(object), result)
       if (isDeep) {
-        result = baseClone(result, CLONE_DEEP_FLAG | CLONE_FLAT_FLAG | CLONE_SYMBOLS_FLAG, customOmitClone);
+        result = baseClone(result, CLONE_DEEP_FLAG | CLONE_FLAT_FLAG | CLONE_SYMBOLS_FLAG, customOmitClone)
       }
-      var length = paths.length;
+      var length = paths.length
       while (length--) {
-        baseUnset(result, paths[length]);
+        baseUnset(result, paths[length])
       }
-      return result;
-    });
+      return result
+    })
 
     /**
      * The opposite of `_.pickBy`; this method creates an object composed of
@@ -13514,7 +13704,7 @@
      * // => { 'b': '2' }
      */
     function omitBy(object, predicate) {
-      return pickBy(object, negate(getIteratee(predicate)));
+      return pickBy(object, negate(getIteratee(predicate)))
     }
 
     /**
@@ -13535,8 +13725,8 @@
      * // => { 'a': 1, 'c': 3 }
      */
     var pick = flatRest(function(object, paths) {
-      return object == null ? {} : basePick(object, paths);
-    });
+      return object == null ? {} : basePick(object, paths)
+    })
 
     /**
      * Creates an object composed of the `object` properties `predicate` returns
@@ -13558,15 +13748,15 @@
      */
     function pickBy(object, predicate) {
       if (object == null) {
-        return {};
+        return {}
       }
       var props = arrayMap(getAllKeysIn(object), function(prop) {
-        return [prop];
-      });
-      predicate = getIteratee(predicate);
+        return [prop]
+      })
+      predicate = getIteratee(predicate)
       return basePickBy(object, props, function(value, path) {
-        return predicate(value, path[0]);
-      });
+        return predicate(value, path[0])
+      })
     }
 
     /**
@@ -13599,25 +13789,25 @@
      * // => 'default'
      */
     function result(object, path, defaultValue) {
-      path = castPath(path, object);
+      path = castPath(path, object)
 
       var index = -1,
-          length = path.length;
+        length = path.length
 
       // Ensure the loop is entered when path is empty.
       if (!length) {
-        length = 1;
-        object = undefined;
+        length = 1
+        object = undefined
       }
       while (++index < length) {
-        var value = object == null ? undefined : object[toKey(path[index])];
+        var value = object == null ? undefined : object[toKey(path[index])]
         if (value === undefined) {
-          index = length;
-          value = defaultValue;
+          index = length
+          value = defaultValue
         }
-        object = isFunction(value) ? value.call(object) : value;
+        object = isFunction(value) ? value.call(object) : value
       }
-      return object;
+      return object
     }
 
     /**
@@ -13649,7 +13839,7 @@
      * // => 5
      */
     function set(object, path, value) {
-      return object == null ? object : baseSet(object, path, value);
+      return object == null ? object : baseSet(object, path, value)
     }
 
     /**
@@ -13677,8 +13867,8 @@
      * // => { '0': { '1': 'a' } }
      */
     function setWith(object, path, value, customizer) {
-      customizer = typeof customizer == 'function' ? customizer : undefined;
-      return object == null ? object : baseSet(object, path, value, customizer);
+      customizer = typeof customizer == 'function' ? customizer : undefined
+      return object == null ? object : baseSet(object, path, value, customizer)
     }
 
     /**
@@ -13705,7 +13895,7 @@
      * _.toPairs(new Foo);
      * // => [['a', 1], ['b', 2]] (iteration order is not guaranteed)
      */
-    var toPairs = createToPairs(keys);
+    var toPairs = createToPairs(keys)
 
     /**
      * Creates an array of own and inherited enumerable string keyed-value pairs
@@ -13731,7 +13921,7 @@
      * _.toPairsIn(new Foo);
      * // => [['a', 1], ['b', 2], ['c', 3]] (iteration order is not guaranteed)
      */
-    var toPairsIn = createToPairs(keysIn);
+    var toPairsIn = createToPairs(keysIn)
 
     /**
      * An alternative to `_.reduce`; this method transforms `object` to a new
@@ -13765,25 +13955,23 @@
      */
     function transform(object, iteratee, accumulator) {
       var isArr = isArray(object),
-          isArrLike = isArr || isBuffer(object) || isTypedArray(object);
+        isArrLike = isArr || isBuffer(object) || isTypedArray(object)
 
-      iteratee = getIteratee(iteratee, 4);
+      iteratee = getIteratee(iteratee, 4)
       if (accumulator == null) {
-        var Ctor = object && object.constructor;
+        var Ctor = object && object.constructor
         if (isArrLike) {
-          accumulator = isArr ? new Ctor : [];
-        }
-        else if (isObject(object)) {
-          accumulator = isFunction(Ctor) ? baseCreate(getPrototype(object)) : {};
-        }
-        else {
-          accumulator = {};
+          accumulator = isArr ? new Ctor() : []
+        } else if (isObject(object)) {
+          accumulator = isFunction(Ctor) ? baseCreate(getPrototype(object)) : {}
+        } else {
+          accumulator = {}
         }
       }
-      (isArrLike ? arrayEach : baseForOwn)(object, function(value, index, object) {
-        return iteratee(accumulator, value, index, object);
-      });
-      return accumulator;
+      ;(isArrLike ? arrayEach : baseForOwn)(object, function(value, index, object) {
+        return iteratee(accumulator, value, index, object)
+      })
+      return accumulator
     }
 
     /**
@@ -13814,7 +14002,7 @@
      * // => { 'a': [{ 'b': {} }] };
      */
     function unset(object, path) {
-      return object == null ? true : baseUnset(object, path);
+      return object == null ? true : baseUnset(object, path)
     }
 
     /**
@@ -13845,7 +14033,7 @@
      * // => 0
      */
     function update(object, path, updater) {
-      return object == null ? object : baseUpdate(object, path, castFunction(updater));
+      return object == null ? object : baseUpdate(object, path, castFunction(updater))
     }
 
     /**
@@ -13873,8 +14061,8 @@
      * // => { '0': { '1': 'a' } }
      */
     function updateWith(object, path, updater, customizer) {
-      customizer = typeof customizer == 'function' ? customizer : undefined;
-      return object == null ? object : baseUpdate(object, path, castFunction(updater), customizer);
+      customizer = typeof customizer == 'function' ? customizer : undefined
+      return object == null ? object : baseUpdate(object, path, castFunction(updater), customizer)
     }
 
     /**
@@ -13904,7 +14092,7 @@
      * // => ['h', 'i']
      */
     function values(object) {
-      return object == null ? [] : baseValues(object, keys(object));
+      return object == null ? [] : baseValues(object, keys(object))
     }
 
     /**
@@ -13932,7 +14120,7 @@
      * // => [1, 2, 3] (iteration order is not guaranteed)
      */
     function valuesIn(object) {
-      return object == null ? [] : baseValues(object, keysIn(object));
+      return object == null ? [] : baseValues(object, keysIn(object))
     }
 
     /*------------------------------------------------------------------------*/
@@ -13958,18 +14146,18 @@
      */
     function clamp(number, lower, upper) {
       if (upper === undefined) {
-        upper = lower;
-        lower = undefined;
+        upper = lower
+        lower = undefined
       }
       if (upper !== undefined) {
-        upper = toNumber(upper);
-        upper = upper === upper ? upper : 0;
+        upper = toNumber(upper)
+        upper = upper === upper ? upper : 0
       }
       if (lower !== undefined) {
-        lower = toNumber(lower);
-        lower = lower === lower ? lower : 0;
+        lower = toNumber(lower)
+        lower = lower === lower ? lower : 0
       }
-      return baseClamp(toNumber(number), lower, upper);
+      return baseClamp(toNumber(number), lower, upper)
     }
 
     /**
@@ -14011,15 +14199,15 @@
      * // => true
      */
     function inRange(number, start, end) {
-      start = toFinite(start);
+      start = toFinite(start)
       if (end === undefined) {
-        end = start;
-        start = 0;
+        end = start
+        start = 0
       } else {
-        end = toFinite(end);
+        end = toFinite(end)
       }
-      number = toNumber(number);
-      return baseInRange(number, start, end);
+      number = toNumber(number)
+      return baseInRange(number, start, end)
     }
 
     /**
@@ -14055,41 +14243,39 @@
      */
     function random(lower, upper, floating) {
       if (floating && typeof floating != 'boolean' && isIterateeCall(lower, upper, floating)) {
-        upper = floating = undefined;
+        upper = floating = undefined
       }
       if (floating === undefined) {
         if (typeof upper == 'boolean') {
-          floating = upper;
-          upper = undefined;
-        }
-        else if (typeof lower == 'boolean') {
-          floating = lower;
-          lower = undefined;
+          floating = upper
+          upper = undefined
+        } else if (typeof lower == 'boolean') {
+          floating = lower
+          lower = undefined
         }
       }
       if (lower === undefined && upper === undefined) {
-        lower = 0;
-        upper = 1;
-      }
-      else {
-        lower = toFinite(lower);
+        lower = 0
+        upper = 1
+      } else {
+        lower = toFinite(lower)
         if (upper === undefined) {
-          upper = lower;
-          lower = 0;
+          upper = lower
+          lower = 0
         } else {
-          upper = toFinite(upper);
+          upper = toFinite(upper)
         }
       }
       if (lower > upper) {
-        var temp = lower;
-        lower = upper;
-        upper = temp;
+        var temp = lower
+        lower = upper
+        upper = temp
       }
       if (floating || lower % 1 || upper % 1) {
-        var rand = nativeRandom();
-        return nativeMin(lower + (rand * (upper - lower + freeParseFloat('1e-' + ((rand + '').length - 1)))), upper);
+        var rand = nativeRandom()
+        return nativeMin(lower + rand * (upper - lower + freeParseFloat('1e-' + ((rand + '').length - 1))), upper)
       }
-      return baseRandom(lower, upper);
+      return baseRandom(lower, upper)
     }
 
     /*------------------------------------------------------------------------*/
@@ -14115,9 +14301,9 @@
      * // => 'fooBar'
      */
     var camelCase = createCompounder(function(result, word, index) {
-      word = word.toLowerCase();
-      return result + (index ? capitalize(word) : word);
-    });
+      word = word.toLowerCase()
+      return result + (index ? capitalize(word) : word)
+    })
 
     /**
      * Converts the first character of `string` to upper case and the remaining
@@ -14135,7 +14321,7 @@
      * // => 'Fred'
      */
     function capitalize(string) {
-      return upperFirst(toString(string).toLowerCase());
+      return upperFirst(toString(string).toLowerCase())
     }
 
     /**
@@ -14157,8 +14343,8 @@
      * // => 'deja vu'
      */
     function deburr(string) {
-      string = toString(string);
-      return string && string.replace(reLatin, deburrLetter).replace(reComboMark, '');
+      string = toString(string)
+      return string && string.replace(reLatin, deburrLetter).replace(reComboMark, '')
     }
 
     /**
@@ -14185,17 +14371,15 @@
      * // => true
      */
     function endsWith(string, target, position) {
-      string = toString(string);
-      target = baseToString(target);
+      string = toString(string)
+      target = baseToString(target)
 
-      var length = string.length;
-      position = position === undefined
-        ? length
-        : baseClamp(toInteger(position), 0, length);
+      var length = string.length
+      position = position === undefined ? length : baseClamp(toInteger(position), 0, length)
 
-      var end = position;
-      position -= target.length;
-      return position >= 0 && string.slice(position, end) == target;
+      var end = position
+      position -= target.length
+      return position >= 0 && string.slice(position, end) == target
     }
 
     /**
@@ -14227,10 +14411,8 @@
      * // => 'fred, barney, &amp; pebbles'
      */
     function escape(string) {
-      string = toString(string);
-      return (string && reHasUnescapedHtml.test(string))
-        ? string.replace(reUnescapedHtml, escapeHtmlChar)
-        : string;
+      string = toString(string)
+      return string && reHasUnescapedHtml.test(string) ? string.replace(reUnescapedHtml, escapeHtmlChar) : string
     }
 
     /**
@@ -14249,10 +14431,8 @@
      * // => '\[lodash\]\(https://lodash\.com/\)'
      */
     function escapeRegExp(string) {
-      string = toString(string);
-      return (string && reHasRegExpChar.test(string))
-        ? string.replace(reRegExpChar, '\\$&')
-        : string;
+      string = toString(string)
+      return string && reHasRegExpChar.test(string) ? string.replace(reRegExpChar, '\\$&') : string
     }
 
     /**
@@ -14277,8 +14457,8 @@
      * // => 'foo-bar'
      */
     var kebabCase = createCompounder(function(result, word, index) {
-      return result + (index ? '-' : '') + word.toLowerCase();
-    });
+      return result + (index ? '-' : '') + word.toLowerCase()
+    })
 
     /**
      * Converts `string`, as space separated words, to lower case.
@@ -14301,8 +14481,8 @@
      * // => 'foo bar'
      */
     var lowerCase = createCompounder(function(result, word, index) {
-      return result + (index ? ' ' : '') + word.toLowerCase();
-    });
+      return result + (index ? ' ' : '') + word.toLowerCase()
+    })
 
     /**
      * Converts the first character of `string` to lower case.
@@ -14321,7 +14501,7 @@
      * _.lowerFirst('FRED');
      * // => 'fRED'
      */
-    var lowerFirst = createCaseFirst('toLowerCase');
+    var lowerFirst = createCaseFirst('toLowerCase')
 
     /**
      * Pads `string` on the left and right sides if it's shorter than `length`.
@@ -14347,19 +14527,15 @@
      * // => 'abc'
      */
     function pad(string, length, chars) {
-      string = toString(string);
-      length = toInteger(length);
+      string = toString(string)
+      length = toInteger(length)
 
-      var strLength = length ? stringSize(string) : 0;
+      var strLength = length ? stringSize(string) : 0
       if (!length || strLength >= length) {
-        return string;
+        return string
       }
-      var mid = (length - strLength) / 2;
-      return (
-        createPadding(nativeFloor(mid), chars) +
-        string +
-        createPadding(nativeCeil(mid), chars)
-      );
+      var mid = (length - strLength) / 2
+      return createPadding(nativeFloor(mid), chars) + string + createPadding(nativeCeil(mid), chars)
     }
 
     /**
@@ -14386,13 +14562,11 @@
      * // => 'abc'
      */
     function padEnd(string, length, chars) {
-      string = toString(string);
-      length = toInteger(length);
+      string = toString(string)
+      length = toInteger(length)
 
-      var strLength = length ? stringSize(string) : 0;
-      return (length && strLength < length)
-        ? (string + createPadding(length - strLength, chars))
-        : string;
+      var strLength = length ? stringSize(string) : 0
+      return length && strLength < length ? string + createPadding(length - strLength, chars) : string
     }
 
     /**
@@ -14419,13 +14593,11 @@
      * // => 'abc'
      */
     function padStart(string, length, chars) {
-      string = toString(string);
-      length = toInteger(length);
+      string = toString(string)
+      length = toInteger(length)
 
-      var strLength = length ? stringSize(string) : 0;
-      return (length && strLength < length)
-        ? (createPadding(length - strLength, chars) + string)
-        : string;
+      var strLength = length ? stringSize(string) : 0
+      return length && strLength < length ? createPadding(length - strLength, chars) + string : string
     }
 
     /**
@@ -14454,11 +14626,11 @@
      */
     function parseInt(string, radix, guard) {
       if (guard || radix == null) {
-        radix = 0;
+        radix = 0
       } else if (radix) {
-        radix = +radix;
+        radix = +radix
       }
-      return nativeParseInt(toString(string).replace(reTrimStart, ''), radix || 0);
+      return nativeParseInt(toString(string).replace(reTrimStart, ''), radix || 0)
     }
 
     /**
@@ -14484,12 +14656,12 @@
      * // => ''
      */
     function repeat(string, n, guard) {
-      if ((guard ? isIterateeCall(string, n, guard) : n === undefined)) {
-        n = 1;
+      if (guard ? isIterateeCall(string, n, guard) : n === undefined) {
+        n = 1
       } else {
-        n = toInteger(n);
+        n = toInteger(n)
       }
-      return baseRepeat(toString(string), n);
+      return baseRepeat(toString(string), n)
     }
 
     /**
@@ -14513,9 +14685,9 @@
      */
     function replace() {
       var args = arguments,
-          string = toString(args[0]);
+        string = toString(args[0])
 
-      return args.length < 3 ? string : string.replace(args[1], args[2]);
+      return args.length < 3 ? string : string.replace(args[1], args[2])
     }
 
     /**
@@ -14540,8 +14712,8 @@
      * // => 'foo_bar'
      */
     var snakeCase = createCompounder(function(result, word, index) {
-      return result + (index ? '_' : '') + word.toLowerCase();
-    });
+      return result + (index ? '_' : '') + word.toLowerCase()
+    })
 
     /**
      * Splits `string` by `separator`.
@@ -14564,23 +14736,20 @@
      */
     function split(string, separator, limit) {
       if (limit && typeof limit != 'number' && isIterateeCall(string, separator, limit)) {
-        separator = limit = undefined;
+        separator = limit = undefined
       }
-      limit = limit === undefined ? MAX_ARRAY_LENGTH : limit >>> 0;
+      limit = limit === undefined ? MAX_ARRAY_LENGTH : limit >>> 0
       if (!limit) {
-        return [];
+        return []
       }
-      string = toString(string);
-      if (string && (
-            typeof separator == 'string' ||
-            (separator != null && !isRegExp(separator))
-          )) {
-        separator = baseToString(separator);
+      string = toString(string)
+      if (string && (typeof separator == 'string' || (separator != null && !isRegExp(separator)))) {
+        separator = baseToString(separator)
         if (!separator && hasUnicode(string)) {
-          return castSlice(stringToArray(string), 0, limit);
+          return castSlice(stringToArray(string), 0, limit)
         }
       }
-      return string.split(separator, limit);
+      return string.split(separator, limit)
     }
 
     /**
@@ -14605,8 +14774,8 @@
      * // => 'FOO BAR'
      */
     var startCase = createCompounder(function(result, word, index) {
-      return result + (index ? ' ' : '') + upperFirst(word);
-    });
+      return result + (index ? ' ' : '') + upperFirst(word)
+    })
 
     /**
      * Checks if `string` starts with the given target string.
@@ -14632,13 +14801,11 @@
      * // => true
      */
     function startsWith(string, target, position) {
-      string = toString(string);
-      position = position == null
-        ? 0
-        : baseClamp(toInteger(position), 0, string.length);
+      string = toString(string)
+      position = position == null ? 0 : baseClamp(toInteger(position), 0, string.length)
 
-      target = baseToString(target);
-      return string.slice(position, position + target.length) == target;
+      target = baseToString(target)
+      return string.slice(position, position + target.length) == target
     }
 
     /**
@@ -14749,108 +14916,113 @@
       // Based on John Resig's `tmpl` implementation
       // (http://ejohn.org/blog/javascript-micro-templating/)
       // and Laura Doktorova's doT.js (https://github.com/olado/doT).
-      var settings = lodash.templateSettings;
+      var settings = lodash.templateSettings
 
       if (guard && isIterateeCall(string, options, guard)) {
-        options = undefined;
+        options = undefined
       }
-      string = toString(string);
-      options = assignInWith({}, options, settings, customDefaultsAssignIn);
+      string = toString(string)
+      options = assignInWith({}, options, settings, customDefaultsAssignIn)
 
       var imports = assignInWith({}, options.imports, settings.imports, customDefaultsAssignIn),
-          importsKeys = keys(imports),
-          importsValues = baseValues(imports, importsKeys);
+        importsKeys = keys(imports),
+        importsValues = baseValues(imports, importsKeys)
 
       var isEscaping,
-          isEvaluating,
-          index = 0,
-          interpolate = options.interpolate || reNoMatch,
-          source = "__p += '";
+        isEvaluating,
+        index = 0,
+        interpolate = options.interpolate || reNoMatch,
+        source = "__p += '"
 
       // Compile the regexp to match each delimiter.
       var reDelimiters = RegExp(
-        (options.escape || reNoMatch).source + '|' +
-        interpolate.source + '|' +
-        (interpolate === reInterpolate ? reEsTemplate : reNoMatch).source + '|' +
-        (options.evaluate || reNoMatch).source + '|$'
-      , 'g');
+        (options.escape || reNoMatch).source +
+          '|' +
+          interpolate.source +
+          '|' +
+          (interpolate === reInterpolate ? reEsTemplate : reNoMatch).source +
+          '|' +
+          (options.evaluate || reNoMatch).source +
+          '|$',
+        'g'
+      )
 
       // Use a sourceURL for easier debugging.
-      var sourceURL = '//# sourceURL=' +
-        ('sourceURL' in options
-          ? options.sourceURL
-          : ('lodash.templateSources[' + (++templateCounter) + ']')
-        ) + '\n';
+      var sourceURL =
+        '//# sourceURL=' +
+        ('sourceURL' in options ? options.sourceURL : 'lodash.templateSources[' + ++templateCounter + ']') +
+        '\n'
 
-      string.replace(reDelimiters, function(match, escapeValue, interpolateValue, esTemplateValue, evaluateValue, offset) {
-        interpolateValue || (interpolateValue = esTemplateValue);
+      string.replace(reDelimiters, function(
+        match,
+        escapeValue,
+        interpolateValue,
+        esTemplateValue,
+        evaluateValue,
+        offset
+      ) {
+        interpolateValue || (interpolateValue = esTemplateValue)
 
         // Escape characters that can't be included in string literals.
-        source += string.slice(index, offset).replace(reUnescapedString, escapeStringChar);
+        source += string.slice(index, offset).replace(reUnescapedString, escapeStringChar)
 
         // Replace delimiters with snippets.
         if (escapeValue) {
-          isEscaping = true;
-          source += "' +\n__e(" + escapeValue + ") +\n'";
+          isEscaping = true
+          source += "' +\n__e(" + escapeValue + ") +\n'"
         }
         if (evaluateValue) {
-          isEvaluating = true;
-          source += "';\n" + evaluateValue + ";\n__p += '";
+          isEvaluating = true
+          source += "';\n" + evaluateValue + ";\n__p += '"
         }
         if (interpolateValue) {
-          source += "' +\n((__t = (" + interpolateValue + ")) == null ? '' : __t) +\n'";
+          source += "' +\n((__t = (" + interpolateValue + ")) == null ? '' : __t) +\n'"
         }
-        index = offset + match.length;
+        index = offset + match.length
 
         // The JS engine embedded in Adobe products needs `match` returned in
         // order to produce the correct `offset` value.
-        return match;
-      });
+        return match
+      })
 
-      source += "';\n";
+      source += "';\n"
 
       // If `variable` is not specified wrap a with-statement around the generated
       // code to add the data object to the top of the scope chain.
-      var variable = options.variable;
+      var variable = options.variable
       if (!variable) {
-        source = 'with (obj) {\n' + source + '\n}\n';
+        source = 'with (obj) {\n' + source + '\n}\n'
       }
       // Cleanup code by stripping empty strings.
       source = (isEvaluating ? source.replace(reEmptyStringLeading, '') : source)
         .replace(reEmptyStringMiddle, '$1')
-        .replace(reEmptyStringTrailing, '$1;');
+        .replace(reEmptyStringTrailing, '$1;')
 
       // Frame code as the function body.
-      source = 'function(' + (variable || 'obj') + ') {\n' +
-        (variable
-          ? ''
-          : 'obj || (obj = {});\n'
-        ) +
+      source =
+        'function(' +
+        (variable || 'obj') +
+        ') {\n' +
+        (variable ? '' : 'obj || (obj = {});\n') +
         "var __t, __p = ''" +
-        (isEscaping
-           ? ', __e = _.escape'
-           : ''
-        ) +
+        (isEscaping ? ', __e = _.escape' : '') +
         (isEvaluating
-          ? ', __j = Array.prototype.join;\n' +
-            "function print() { __p += __j.call(arguments, '') }\n"
-          : ';\n'
-        ) +
+          ? ', __j = Array.prototype.join;\n' + "function print() { __p += __j.call(arguments, '') }\n"
+          : ';\n') +
         source +
-        'return __p\n}';
+        'return __p\n}'
 
       var result = attempt(function() {
-        return Function(importsKeys, sourceURL + 'return ' + source)
-          .apply(undefined, importsValues);
-      });
+        return Function(importsKeys, sourceURL + 'return ' + source).apply(undefined, importsValues)
+      })
 
       // Provide the compiled function's source by its `toString` method or
       // the `source` property as a convenience for inlining compiled templates.
-      result.source = source;
+      result.source = source
       if (isError(result)) {
-        throw result;
+        throw result
       }
-      return result;
+      return result
     }
 
     /**
@@ -14875,7 +15047,7 @@
      * // => '__foo_bar__'
      */
     function toLower(value) {
-      return toString(value).toLowerCase();
+      return toString(value).toLowerCase()
     }
 
     /**
@@ -14900,7 +15072,7 @@
      * // => '__FOO_BAR__'
      */
     function toUpper(value) {
-      return toString(value).toUpperCase();
+      return toString(value).toUpperCase()
     }
 
     /**
@@ -14926,19 +15098,19 @@
      * // => ['foo', 'bar']
      */
     function trim(string, chars, guard) {
-      string = toString(string);
+      string = toString(string)
       if (string && (guard || chars === undefined)) {
-        return string.replace(reTrim, '');
+        return string.replace(reTrim, '')
       }
       if (!string || !(chars = baseToString(chars))) {
-        return string;
+        return string
       }
       var strSymbols = stringToArray(string),
-          chrSymbols = stringToArray(chars),
-          start = charsStartIndex(strSymbols, chrSymbols),
-          end = charsEndIndex(strSymbols, chrSymbols) + 1;
+        chrSymbols = stringToArray(chars),
+        start = charsStartIndex(strSymbols, chrSymbols),
+        end = charsEndIndex(strSymbols, chrSymbols) + 1
 
-      return castSlice(strSymbols, start, end).join('');
+      return castSlice(strSymbols, start, end).join('')
     }
 
     /**
@@ -14961,17 +15133,17 @@
      * // => '-_-abc'
      */
     function trimEnd(string, chars, guard) {
-      string = toString(string);
+      string = toString(string)
       if (string && (guard || chars === undefined)) {
-        return string.replace(reTrimEnd, '');
+        return string.replace(reTrimEnd, '')
       }
       if (!string || !(chars = baseToString(chars))) {
-        return string;
+        return string
       }
       var strSymbols = stringToArray(string),
-          end = charsEndIndex(strSymbols, stringToArray(chars)) + 1;
+        end = charsEndIndex(strSymbols, stringToArray(chars)) + 1
 
-      return castSlice(strSymbols, 0, end).join('');
+      return castSlice(strSymbols, 0, end).join('')
     }
 
     /**
@@ -14994,17 +15166,17 @@
      * // => 'abc-_-'
      */
     function trimStart(string, chars, guard) {
-      string = toString(string);
+      string = toString(string)
       if (string && (guard || chars === undefined)) {
-        return string.replace(reTrimStart, '');
+        return string.replace(reTrimStart, '')
       }
       if (!string || !(chars = baseToString(chars))) {
-        return string;
+        return string
       }
       var strSymbols = stringToArray(string),
-          start = charsStartIndex(strSymbols, stringToArray(chars));
+        start = charsStartIndex(strSymbols, stringToArray(chars))
 
-      return castSlice(strSymbols, start).join('');
+      return castSlice(strSymbols, start).join('')
     }
 
     /**
@@ -15046,58 +15218,56 @@
      */
     function truncate(string, options) {
       var length = DEFAULT_TRUNC_LENGTH,
-          omission = DEFAULT_TRUNC_OMISSION;
+        omission = DEFAULT_TRUNC_OMISSION
 
       if (isObject(options)) {
-        var separator = 'separator' in options ? options.separator : separator;
-        length = 'length' in options ? toInteger(options.length) : length;
-        omission = 'omission' in options ? baseToString(options.omission) : omission;
+        var separator = 'separator' in options ? options.separator : separator
+        length = 'length' in options ? toInteger(options.length) : length
+        omission = 'omission' in options ? baseToString(options.omission) : omission
       }
-      string = toString(string);
+      string = toString(string)
 
-      var strLength = string.length;
+      var strLength = string.length
       if (hasUnicode(string)) {
-        var strSymbols = stringToArray(string);
-        strLength = strSymbols.length;
+        var strSymbols = stringToArray(string)
+        strLength = strSymbols.length
       }
       if (length >= strLength) {
-        return string;
+        return string
       }
-      var end = length - stringSize(omission);
+      var end = length - stringSize(omission)
       if (end < 1) {
-        return omission;
+        return omission
       }
-      var result = strSymbols
-        ? castSlice(strSymbols, 0, end).join('')
-        : string.slice(0, end);
+      var result = strSymbols ? castSlice(strSymbols, 0, end).join('') : string.slice(0, end)
 
       if (separator === undefined) {
-        return result + omission;
+        return result + omission
       }
       if (strSymbols) {
-        end += (result.length - end);
+        end += result.length - end
       }
       if (isRegExp(separator)) {
         if (string.slice(end).search(separator)) {
           var match,
-              substring = result;
+            substring = result
 
           if (!separator.global) {
-            separator = RegExp(separator.source, toString(reFlags.exec(separator)) + 'g');
+            separator = RegExp(separator.source, toString(reFlags.exec(separator)) + 'g')
           }
-          separator.lastIndex = 0;
+          separator.lastIndex = 0
           while ((match = separator.exec(substring))) {
-            var newEnd = match.index;
+            var newEnd = match.index
           }
-          result = result.slice(0, newEnd === undefined ? end : newEnd);
+          result = result.slice(0, newEnd === undefined ? end : newEnd)
         }
       } else if (string.indexOf(baseToString(separator), end) != end) {
-        var index = result.lastIndexOf(separator);
+        var index = result.lastIndexOf(separator)
         if (index > -1) {
-          result = result.slice(0, index);
+          result = result.slice(0, index)
         }
       }
-      return result + omission;
+      return result + omission
     }
 
     /**
@@ -15120,10 +15290,8 @@
      * // => 'fred, barney, & pebbles'
      */
     function unescape(string) {
-      string = toString(string);
-      return (string && reHasEscapedHtml.test(string))
-        ? string.replace(reEscapedHtml, unescapeHtmlChar)
-        : string;
+      string = toString(string)
+      return string && reHasEscapedHtml.test(string) ? string.replace(reEscapedHtml, unescapeHtmlChar) : string
     }
 
     /**
@@ -15147,8 +15315,8 @@
      * // => 'FOO BAR'
      */
     var upperCase = createCompounder(function(result, word, index) {
-      return result + (index ? ' ' : '') + word.toUpperCase();
-    });
+      return result + (index ? ' ' : '') + word.toUpperCase()
+    })
 
     /**
      * Converts the first character of `string` to upper case.
@@ -15167,7 +15335,7 @@
      * _.upperFirst('FRED');
      * // => 'FRED'
      */
-    var upperFirst = createCaseFirst('toUpperCase');
+    var upperFirst = createCaseFirst('toUpperCase')
 
     /**
      * Splits `string` into an array of its words.
@@ -15189,13 +15357,13 @@
      * // => ['fred', 'barney', '&', 'pebbles']
      */
     function words(string, pattern, guard) {
-      string = toString(string);
-      pattern = guard ? undefined : pattern;
+      string = toString(string)
+      pattern = guard ? undefined : pattern
 
       if (pattern === undefined) {
-        return hasUnicodeWord(string) ? unicodeWords(string) : asciiWords(string);
+        return hasUnicodeWord(string) ? unicodeWords(string) : asciiWords(string)
       }
-      return string.match(pattern) || [];
+      return string.match(pattern) || []
     }
 
     /*------------------------------------------------------------------------*/
@@ -15224,11 +15392,11 @@
      */
     var attempt = baseRest(function(func, args) {
       try {
-        return apply(func, undefined, args);
+        return apply(func, undefined, args)
       } catch (e) {
-        return isError(e) ? e : new Error(e);
+        return isError(e) ? e : new Error(e)
       }
-    });
+    })
 
     /**
      * Binds methods of an object to the object itself, overwriting the existing
@@ -15258,11 +15426,11 @@
      */
     var bindAll = flatRest(function(object, methodNames) {
       arrayEach(methodNames, function(key) {
-        key = toKey(key);
-        baseAssignValue(object, key, bind(object[key], object));
-      });
-      return object;
-    });
+        key = toKey(key)
+        baseAssignValue(object, key, bind(object[key], object))
+      })
+      return object
+    })
 
     /**
      * Creates a function that iterates over `pairs` and invokes the corresponding
@@ -15295,24 +15463,26 @@
      */
     function cond(pairs) {
       var length = pairs == null ? 0 : pairs.length,
-          toIteratee = getIteratee();
+        toIteratee = getIteratee()
 
-      pairs = !length ? [] : arrayMap(pairs, function(pair) {
-        if (typeof pair[1] != 'function') {
-          throw new TypeError(FUNC_ERROR_TEXT);
-        }
-        return [toIteratee(pair[0]), pair[1]];
-      });
+      pairs = !length
+        ? []
+        : arrayMap(pairs, function(pair) {
+            if (typeof pair[1] != 'function') {
+              throw new TypeError(FUNC_ERROR_TEXT)
+            }
+            return [toIteratee(pair[0]), pair[1]]
+          })
 
       return baseRest(function(args) {
-        var index = -1;
+        var index = -1
         while (++index < length) {
-          var pair = pairs[index];
+          var pair = pairs[index]
           if (apply(pair[0], this, args)) {
-            return apply(pair[1], this, args);
+            return apply(pair[1], this, args)
           }
         }
-      });
+      })
     }
 
     /**
@@ -15340,7 +15510,7 @@
      * // => [{ 'a': 1, 'b': 2 }]
      */
     function conforms(source) {
-      return baseConforms(baseClone(source, CLONE_DEEP_FLAG));
+      return baseConforms(baseClone(source, CLONE_DEEP_FLAG))
     }
 
     /**
@@ -15364,8 +15534,8 @@
      */
     function constant(value) {
       return function() {
-        return value;
-      };
+        return value
+      }
     }
 
     /**
@@ -15389,7 +15559,7 @@
      * // => 10
      */
     function defaultTo(value, defaultValue) {
-      return (value == null || value !== value) ? defaultValue : value;
+      return value == null || value !== value ? defaultValue : value
     }
 
     /**
@@ -15414,7 +15584,7 @@
      * addSquare(1, 2);
      * // => 9
      */
-    var flow = createFlow();
+    var flow = createFlow()
 
     /**
      * This method is like `_.flow` except that it creates a function that
@@ -15437,7 +15607,7 @@
      * addSquare(1, 2);
      * // => 9
      */
-    var flowRight = createFlow(true);
+    var flowRight = createFlow(true)
 
     /**
      * This method returns the first argument it receives.
@@ -15456,7 +15626,7 @@
      * // => true
      */
     function identity(value) {
-      return value;
+      return value
     }
 
     /**
@@ -15502,7 +15672,7 @@
      * // => ['def']
      */
     function iteratee(func) {
-      return baseIteratee(typeof func == 'function' ? func : baseClone(func, CLONE_DEEP_FLAG));
+      return baseIteratee(typeof func == 'function' ? func : baseClone(func, CLONE_DEEP_FLAG))
     }
 
     /**
@@ -15534,7 +15704,7 @@
      * // => [{ 'a': 4, 'b': 5, 'c': 6 }]
      */
     function matches(source) {
-      return baseMatches(baseClone(source, CLONE_DEEP_FLAG));
+      return baseMatches(baseClone(source, CLONE_DEEP_FLAG))
     }
 
     /**
@@ -15564,7 +15734,7 @@
      * // => { 'a': 4, 'b': 5, 'c': 6 }
      */
     function matchesProperty(path, srcValue) {
-      return baseMatchesProperty(path, baseClone(srcValue, CLONE_DEEP_FLAG));
+      return baseMatchesProperty(path, baseClone(srcValue, CLONE_DEEP_FLAG))
     }
 
     /**
@@ -15593,9 +15763,9 @@
      */
     var method = baseRest(function(path, args) {
       return function(object) {
-        return baseInvoke(object, path, args);
-      };
-    });
+        return baseInvoke(object, path, args)
+      }
+    })
 
     /**
      * The opposite of `_.method`; this method creates a function that invokes
@@ -15622,9 +15792,9 @@
      */
     var methodOf = baseRest(function(object, args) {
       return function(path) {
-        return baseInvoke(object, path, args);
-      };
-    });
+        return baseInvoke(object, path, args)
+      }
+    })
 
     /**
      * Adds all own enumerable string keyed function properties of a source
@@ -15664,38 +15834,37 @@
      */
     function mixin(object, source, options) {
       var props = keys(source),
-          methodNames = baseFunctions(source, props);
+        methodNames = baseFunctions(source, props)
 
-      if (options == null &&
-          !(isObject(source) && (methodNames.length || !props.length))) {
-        options = source;
-        source = object;
-        object = this;
-        methodNames = baseFunctions(source, keys(source));
+      if (options == null && !(isObject(source) && (methodNames.length || !props.length))) {
+        options = source
+        source = object
+        object = this
+        methodNames = baseFunctions(source, keys(source))
       }
       var chain = !(isObject(options) && 'chain' in options) || !!options.chain,
-          isFunc = isFunction(object);
+        isFunc = isFunction(object)
 
       arrayEach(methodNames, function(methodName) {
-        var func = source[methodName];
-        object[methodName] = func;
+        var func = source[methodName]
+        object[methodName] = func
         if (isFunc) {
           object.prototype[methodName] = function() {
-            var chainAll = this.__chain__;
+            var chainAll = this.__chain__
             if (chain || chainAll) {
               var result = object(this.__wrapped__),
-                  actions = result.__actions__ = copyArray(this.__actions__);
+                actions = (result.__actions__ = copyArray(this.__actions__))
 
-              actions.push({ 'func': func, 'args': arguments, 'thisArg': object });
-              result.__chain__ = chainAll;
-              return result;
+              actions.push({func: func, args: arguments, thisArg: object})
+              result.__chain__ = chainAll
+              return result
             }
-            return func.apply(object, arrayPush([this.value()], arguments));
-          };
+            return func.apply(object, arrayPush([this.value()], arguments))
+          }
         }
-      });
+      })
 
-      return object;
+      return object
     }
 
     /**
@@ -15713,9 +15882,9 @@
      */
     function noConflict() {
       if (root._ === this) {
-        root._ = oldDash;
+        root._ = oldDash
       }
-      return this;
+      return this
     }
 
     /**
@@ -15755,10 +15924,10 @@
      * // => 'c'
      */
     function nthArg(n) {
-      n = toInteger(n);
+      n = toInteger(n)
       return baseRest(function(args) {
-        return baseNth(args, n);
-      });
+        return baseNth(args, n)
+      })
     }
 
     /**
@@ -15779,7 +15948,7 @@
      * func(1, 2, 3, 4);
      * // => [4, 1]
      */
-    var over = createOver(arrayMap);
+    var over = createOver(arrayMap)
 
     /**
      * Creates a function that checks if **all** of the `predicates` return
@@ -15805,7 +15974,7 @@
      * func(NaN);
      * // => false
      */
-    var overEvery = createOver(arrayEvery);
+    var overEvery = createOver(arrayEvery)
 
     /**
      * Creates a function that checks if **any** of the `predicates` return
@@ -15831,7 +16000,7 @@
      * func(NaN);
      * // => false
      */
-    var overSome = createOver(arraySome);
+    var overSome = createOver(arraySome)
 
     /**
      * Creates a function that returns the value at `path` of a given object.
@@ -15856,7 +16025,7 @@
      * // => [1, 2]
      */
     function property(path) {
-      return isKey(path) ? baseProperty(toKey(path)) : basePropertyDeep(path);
+      return isKey(path) ? baseProperty(toKey(path)) : basePropertyDeep(path)
     }
 
     /**
@@ -15882,8 +16051,8 @@
      */
     function propertyOf(object) {
       return function(path) {
-        return object == null ? undefined : baseGet(object, path);
-      };
+        return object == null ? undefined : baseGet(object, path)
+      }
     }
 
     /**
@@ -15927,7 +16096,7 @@
      * _.range(0);
      * // => []
      */
-    var range = createRange();
+    var range = createRange()
 
     /**
      * This method is like `_.range` except that it populates values in
@@ -15965,7 +16134,7 @@
      * _.rangeRight(0);
      * // => []
      */
-    var rangeRight = createRange(true);
+    var rangeRight = createRange(true)
 
     /**
      * This method returns a new empty array.
@@ -15986,7 +16155,7 @@
      * // => false
      */
     function stubArray() {
-      return [];
+      return []
     }
 
     /**
@@ -16003,7 +16172,7 @@
      * // => [false, false]
      */
     function stubFalse() {
-      return false;
+      return false
     }
 
     /**
@@ -16025,7 +16194,7 @@
      * // => false
      */
     function stubObject() {
-      return {};
+      return {}
     }
 
     /**
@@ -16042,7 +16211,7 @@
      * // => ['', '']
      */
     function stubString() {
-      return '';
+      return ''
     }
 
     /**
@@ -16059,7 +16228,7 @@
      * // => [true, true]
      */
     function stubTrue() {
-      return true;
+      return true
     }
 
     /**
@@ -16082,21 +16251,21 @@
      * // => [0, 0, 0, 0]
      */
     function times(n, iteratee) {
-      n = toInteger(n);
+      n = toInteger(n)
       if (n < 1 || n > MAX_SAFE_INTEGER) {
-        return [];
+        return []
       }
       var index = MAX_ARRAY_LENGTH,
-          length = nativeMin(n, MAX_ARRAY_LENGTH);
+        length = nativeMin(n, MAX_ARRAY_LENGTH)
 
-      iteratee = getIteratee(iteratee);
-      n -= MAX_ARRAY_LENGTH;
+      iteratee = getIteratee(iteratee)
+      n -= MAX_ARRAY_LENGTH
 
-      var result = baseTimes(length, iteratee);
+      var result = baseTimes(length, iteratee)
       while (++index < n) {
-        iteratee(index);
+        iteratee(index)
       }
-      return result;
+      return result
     }
 
     /**
@@ -16118,9 +16287,9 @@
      */
     function toPath(value) {
       if (isArray(value)) {
-        return arrayMap(value, toKey);
+        return arrayMap(value, toKey)
       }
-      return isSymbol(value) ? [value] : copyArray(stringToPath(toString(value)));
+      return isSymbol(value) ? [value] : copyArray(stringToPath(toString(value)))
     }
 
     /**
@@ -16141,8 +16310,8 @@
      * // => '105'
      */
     function uniqueId(prefix) {
-      var id = ++idCounter;
-      return toString(prefix) + id;
+      var id = ++idCounter
+      return toString(prefix) + id
     }
 
     /*------------------------------------------------------------------------*/
@@ -16163,8 +16332,8 @@
      * // => 10
      */
     var add = createMathOperation(function(augend, addend) {
-      return augend + addend;
-    }, 0);
+      return augend + addend
+    }, 0)
 
     /**
      * Computes `number` rounded up to `precision`.
@@ -16187,7 +16356,7 @@
      * _.ceil(6040, -2);
      * // => 6100
      */
-    var ceil = createRound('ceil');
+    var ceil = createRound('ceil')
 
     /**
      * Divide two numbers.
@@ -16205,8 +16374,8 @@
      * // => 1.5
      */
     var divide = createMathOperation(function(dividend, divisor) {
-      return dividend / divisor;
-    }, 1);
+      return dividend / divisor
+    }, 1)
 
     /**
      * Computes `number` rounded down to `precision`.
@@ -16229,7 +16398,7 @@
      * _.floor(4060, -2);
      * // => 4000
      */
-    var floor = createRound('floor');
+    var floor = createRound('floor')
 
     /**
      * Computes the maximum value of `array`. If `array` is empty or falsey,
@@ -16250,9 +16419,7 @@
      * // => undefined
      */
     function max(array) {
-      return (array && array.length)
-        ? baseExtremum(array, identity, baseGt)
-        : undefined;
+      return array && array.length ? baseExtremum(array, identity, baseGt) : undefined
     }
 
     /**
@@ -16279,9 +16446,7 @@
      * // => { 'n': 2 }
      */
     function maxBy(array, iteratee) {
-      return (array && array.length)
-        ? baseExtremum(array, getIteratee(iteratee, 2), baseGt)
-        : undefined;
+      return array && array.length ? baseExtremum(array, getIteratee(iteratee, 2), baseGt) : undefined
     }
 
     /**
@@ -16299,7 +16464,7 @@
      * // => 5
      */
     function mean(array) {
-      return baseMean(array, identity);
+      return baseMean(array, identity)
     }
 
     /**
@@ -16326,7 +16491,7 @@
      * // => 5
      */
     function meanBy(array, iteratee) {
-      return baseMean(array, getIteratee(iteratee, 2));
+      return baseMean(array, getIteratee(iteratee, 2))
     }
 
     /**
@@ -16348,9 +16513,7 @@
      * // => undefined
      */
     function min(array) {
-      return (array && array.length)
-        ? baseExtremum(array, identity, baseLt)
-        : undefined;
+      return array && array.length ? baseExtremum(array, identity, baseLt) : undefined
     }
 
     /**
@@ -16377,9 +16540,7 @@
      * // => { 'n': 1 }
      */
     function minBy(array, iteratee) {
-      return (array && array.length)
-        ? baseExtremum(array, getIteratee(iteratee, 2), baseLt)
-        : undefined;
+      return array && array.length ? baseExtremum(array, getIteratee(iteratee, 2), baseLt) : undefined
     }
 
     /**
@@ -16398,8 +16559,8 @@
      * // => 24
      */
     var multiply = createMathOperation(function(multiplier, multiplicand) {
-      return multiplier * multiplicand;
-    }, 1);
+      return multiplier * multiplicand
+    }, 1)
 
     /**
      * Computes `number` rounded to `precision`.
@@ -16422,7 +16583,7 @@
      * _.round(4060, -2);
      * // => 4100
      */
-    var round = createRound('round');
+    var round = createRound('round')
 
     /**
      * Subtract two numbers.
@@ -16440,8 +16601,8 @@
      * // => 2
      */
     var subtract = createMathOperation(function(minuend, subtrahend) {
-      return minuend - subtrahend;
-    }, 0);
+      return minuend - subtrahend
+    }, 0)
 
     /**
      * Computes the sum of the values in `array`.
@@ -16458,9 +16619,7 @@
      * // => 20
      */
     function sum(array) {
-      return (array && array.length)
-        ? baseSum(array, identity)
-        : 0;
+      return array && array.length ? baseSum(array, identity) : 0
     }
 
     /**
@@ -16487,340 +16646,342 @@
      * // => 20
      */
     function sumBy(array, iteratee) {
-      return (array && array.length)
-        ? baseSum(array, getIteratee(iteratee, 2))
-        : 0;
+      return array && array.length ? baseSum(array, getIteratee(iteratee, 2)) : 0
     }
 
     /*------------------------------------------------------------------------*/
 
     // Add methods that return wrapped values in chain sequences.
-    lodash.after = after;
-    lodash.ary = ary;
-    lodash.assign = assign;
-    lodash.assignIn = assignIn;
-    lodash.assignInWith = assignInWith;
-    lodash.assignWith = assignWith;
-    lodash.at = at;
-    lodash.before = before;
-    lodash.bind = bind;
-    lodash.bindAll = bindAll;
-    lodash.bindKey = bindKey;
-    lodash.castArray = castArray;
-    lodash.chain = chain;
-    lodash.chunk = chunk;
-    lodash.compact = compact;
-    lodash.concat = concat;
-    lodash.cond = cond;
-    lodash.conforms = conforms;
-    lodash.constant = constant;
-    lodash.countBy = countBy;
-    lodash.create = create;
-    lodash.curry = curry;
-    lodash.curryRight = curryRight;
-    lodash.debounce = debounce;
-    lodash.defaults = defaults;
-    lodash.defaultsDeep = defaultsDeep;
-    lodash.defer = defer;
-    lodash.delay = delay;
-    lodash.difference = difference;
-    lodash.differenceBy = differenceBy;
-    lodash.differenceWith = differenceWith;
-    lodash.drop = drop;
-    lodash.dropRight = dropRight;
-    lodash.dropRightWhile = dropRightWhile;
-    lodash.dropWhile = dropWhile;
-    lodash.fill = fill;
-    lodash.filter = filter;
-    lodash.flatMap = flatMap;
-    lodash.flatMapDeep = flatMapDeep;
-    lodash.flatMapDepth = flatMapDepth;
-    lodash.flatten = flatten;
-    lodash.flattenDeep = flattenDeep;
-    lodash.flattenDepth = flattenDepth;
-    lodash.flip = flip;
-    lodash.flow = flow;
-    lodash.flowRight = flowRight;
-    lodash.fromPairs = fromPairs;
-    lodash.functions = functions;
-    lodash.functionsIn = functionsIn;
-    lodash.groupBy = groupBy;
-    lodash.initial = initial;
-    lodash.intersection = intersection;
-    lodash.intersectionBy = intersectionBy;
-    lodash.intersectionWith = intersectionWith;
-    lodash.invert = invert;
-    lodash.invertBy = invertBy;
-    lodash.invokeMap = invokeMap;
-    lodash.iteratee = iteratee;
-    lodash.keyBy = keyBy;
-    lodash.keys = keys;
-    lodash.keysIn = keysIn;
-    lodash.map = map;
-    lodash.mapKeys = mapKeys;
-    lodash.mapValues = mapValues;
-    lodash.matches = matches;
-    lodash.matchesProperty = matchesProperty;
-    lodash.memoize = memoize;
-    lodash.merge = merge;
-    lodash.mergeWith = mergeWith;
-    lodash.method = method;
-    lodash.methodOf = methodOf;
-    lodash.mixin = mixin;
-    lodash.negate = negate;
-    lodash.nthArg = nthArg;
-    lodash.omit = omit;
-    lodash.omitBy = omitBy;
-    lodash.once = once;
-    lodash.orderBy = orderBy;
-    lodash.over = over;
-    lodash.overArgs = overArgs;
-    lodash.overEvery = overEvery;
-    lodash.overSome = overSome;
-    lodash.partial = partial;
-    lodash.partialRight = partialRight;
-    lodash.partition = partition;
-    lodash.pick = pick;
-    lodash.pickBy = pickBy;
-    lodash.property = property;
-    lodash.propertyOf = propertyOf;
-    lodash.pull = pull;
-    lodash.pullAll = pullAll;
-    lodash.pullAllBy = pullAllBy;
-    lodash.pullAllWith = pullAllWith;
-    lodash.pullAt = pullAt;
-    lodash.range = range;
-    lodash.rangeRight = rangeRight;
-    lodash.rearg = rearg;
-    lodash.reject = reject;
-    lodash.remove = remove;
-    lodash.rest = rest;
-    lodash.reverse = reverse;
-    lodash.sampleSize = sampleSize;
-    lodash.set = set;
-    lodash.setWith = setWith;
-    lodash.shuffle = shuffle;
-    lodash.slice = slice;
-    lodash.sortBy = sortBy;
-    lodash.sortedUniq = sortedUniq;
-    lodash.sortedUniqBy = sortedUniqBy;
-    lodash.split = split;
-    lodash.spread = spread;
-    lodash.tail = tail;
-    lodash.take = take;
-    lodash.takeRight = takeRight;
-    lodash.takeRightWhile = takeRightWhile;
-    lodash.takeWhile = takeWhile;
-    lodash.tap = tap;
-    lodash.throttle = throttle;
-    lodash.thru = thru;
-    lodash.toArray = toArray;
-    lodash.toPairs = toPairs;
-    lodash.toPairsIn = toPairsIn;
-    lodash.toPath = toPath;
-    lodash.toPlainObject = toPlainObject;
-    lodash.transform = transform;
-    lodash.unary = unary;
-    lodash.union = union;
-    lodash.unionBy = unionBy;
-    lodash.unionWith = unionWith;
-    lodash.uniq = uniq;
-    lodash.uniqBy = uniqBy;
-    lodash.uniqWith = uniqWith;
-    lodash.unset = unset;
-    lodash.unzip = unzip;
-    lodash.unzipWith = unzipWith;
-    lodash.update = update;
-    lodash.updateWith = updateWith;
-    lodash.values = values;
-    lodash.valuesIn = valuesIn;
-    lodash.without = without;
-    lodash.words = words;
-    lodash.wrap = wrap;
-    lodash.xor = xor;
-    lodash.xorBy = xorBy;
-    lodash.xorWith = xorWith;
-    lodash.zip = zip;
-    lodash.zipObject = zipObject;
-    lodash.zipObjectDeep = zipObjectDeep;
-    lodash.zipWith = zipWith;
+    lodash.after = after
+    lodash.ary = ary
+    lodash.assign = assign
+    lodash.assignIn = assignIn
+    lodash.assignInWith = assignInWith
+    lodash.assignWith = assignWith
+    lodash.at = at
+    lodash.before = before
+    lodash.bind = bind
+    lodash.bindAll = bindAll
+    lodash.bindKey = bindKey
+    lodash.castArray = castArray
+    lodash.chain = chain
+    lodash.chunk = chunk
+    lodash.compact = compact
+    lodash.concat = concat
+    lodash.cond = cond
+    lodash.conforms = conforms
+    lodash.constant = constant
+    lodash.countBy = countBy
+    lodash.create = create
+    lodash.curry = curry
+    lodash.curryRight = curryRight
+    lodash.debounce = debounce
+    lodash.defaults = defaults
+    lodash.defaultsDeep = defaultsDeep
+    lodash.defer = defer
+    lodash.delay = delay
+    lodash.difference = difference
+    lodash.differenceBy = differenceBy
+    lodash.differenceWith = differenceWith
+    lodash.drop = drop
+    lodash.dropRight = dropRight
+    lodash.dropRightWhile = dropRightWhile
+    lodash.dropWhile = dropWhile
+    lodash.fill = fill
+    lodash.filter = filter
+    lodash.flatMap = flatMap
+    lodash.flatMapDeep = flatMapDeep
+    lodash.flatMapDepth = flatMapDepth
+    lodash.flatten = flatten
+    lodash.flattenDeep = flattenDeep
+    lodash.flattenDepth = flattenDepth
+    lodash.flip = flip
+    lodash.flow = flow
+    lodash.flowRight = flowRight
+    lodash.fromPairs = fromPairs
+    lodash.functions = functions
+    lodash.functionsIn = functionsIn
+    lodash.groupBy = groupBy
+    lodash.initial = initial
+    lodash.intersection = intersection
+    lodash.intersectionBy = intersectionBy
+    lodash.intersectionWith = intersectionWith
+    lodash.invert = invert
+    lodash.invertBy = invertBy
+    lodash.invokeMap = invokeMap
+    lodash.iteratee = iteratee
+    lodash.keyBy = keyBy
+    lodash.keys = keys
+    lodash.keysIn = keysIn
+    lodash.map = map
+    lodash.mapKeys = mapKeys
+    lodash.mapValues = mapValues
+    lodash.matches = matches
+    lodash.matchesProperty = matchesProperty
+    lodash.memoize = memoize
+    lodash.merge = merge
+    lodash.mergeWith = mergeWith
+    lodash.method = method
+    lodash.methodOf = methodOf
+    lodash.mixin = mixin
+    lodash.negate = negate
+    lodash.nthArg = nthArg
+    lodash.omit = omit
+    lodash.omitBy = omitBy
+    lodash.once = once
+    lodash.orderBy = orderBy
+    lodash.over = over
+    lodash.overArgs = overArgs
+    lodash.overEvery = overEvery
+    lodash.overSome = overSome
+    lodash.partial = partial
+    lodash.partialRight = partialRight
+    lodash.partition = partition
+    lodash.pick = pick
+    lodash.pickBy = pickBy
+    lodash.property = property
+    lodash.propertyOf = propertyOf
+    lodash.pull = pull
+    lodash.pullAll = pullAll
+    lodash.pullAllBy = pullAllBy
+    lodash.pullAllWith = pullAllWith
+    lodash.pullAt = pullAt
+    lodash.range = range
+    lodash.rangeRight = rangeRight
+    lodash.rearg = rearg
+    lodash.reject = reject
+    lodash.remove = remove
+    lodash.rest = rest
+    lodash.reverse = reverse
+    lodash.sampleSize = sampleSize
+    lodash.set = set
+    lodash.setWith = setWith
+    lodash.shuffle = shuffle
+    lodash.slice = slice
+    lodash.sortBy = sortBy
+    lodash.sortedUniq = sortedUniq
+    lodash.sortedUniqBy = sortedUniqBy
+    lodash.split = split
+    lodash.spread = spread
+    lodash.tail = tail
+    lodash.take = take
+    lodash.takeRight = takeRight
+    lodash.takeRightWhile = takeRightWhile
+    lodash.takeWhile = takeWhile
+    lodash.tap = tap
+    lodash.throttle = throttle
+    lodash.thru = thru
+    lodash.toArray = toArray
+    lodash.toPairs = toPairs
+    lodash.toPairsIn = toPairsIn
+    lodash.toPath = toPath
+    lodash.toPlainObject = toPlainObject
+    lodash.transform = transform
+    lodash.unary = unary
+    lodash.union = union
+    lodash.unionBy = unionBy
+    lodash.unionWith = unionWith
+    lodash.uniq = uniq
+    lodash.uniqBy = uniqBy
+    lodash.uniqWith = uniqWith
+    lodash.unset = unset
+    lodash.unzip = unzip
+    lodash.unzipWith = unzipWith
+    lodash.update = update
+    lodash.updateWith = updateWith
+    lodash.values = values
+    lodash.valuesIn = valuesIn
+    lodash.without = without
+    lodash.words = words
+    lodash.wrap = wrap
+    lodash.xor = xor
+    lodash.xorBy = xorBy
+    lodash.xorWith = xorWith
+    lodash.zip = zip
+    lodash.zipObject = zipObject
+    lodash.zipObjectDeep = zipObjectDeep
+    lodash.zipWith = zipWith
 
     // Add aliases.
-    lodash.entries = toPairs;
-    lodash.entriesIn = toPairsIn;
-    lodash.extend = assignIn;
-    lodash.extendWith = assignInWith;
+    lodash.entries = toPairs
+    lodash.entriesIn = toPairsIn
+    lodash.extend = assignIn
+    lodash.extendWith = assignInWith
 
     // Add methods to `lodash.prototype`.
-    mixin(lodash, lodash);
+    mixin(lodash, lodash)
 
     /*------------------------------------------------------------------------*/
 
     // Add methods that return unwrapped values in chain sequences.
-    lodash.add = add;
-    lodash.attempt = attempt;
-    lodash.camelCase = camelCase;
-    lodash.capitalize = capitalize;
-    lodash.ceil = ceil;
-    lodash.clamp = clamp;
-    lodash.clone = clone;
-    lodash.cloneDeep = cloneDeep;
-    lodash.cloneDeepWith = cloneDeepWith;
-    lodash.cloneWith = cloneWith;
-    lodash.conformsTo = conformsTo;
-    lodash.deburr = deburr;
-    lodash.defaultTo = defaultTo;
-    lodash.divide = divide;
-    lodash.endsWith = endsWith;
-    lodash.eq = eq;
-    lodash.escape = escape;
-    lodash.escapeRegExp = escapeRegExp;
-    lodash.every = every;
-    lodash.find = find;
-    lodash.findIndex = findIndex;
-    lodash.findKey = findKey;
-    lodash.findLast = findLast;
-    lodash.findLastIndex = findLastIndex;
-    lodash.findLastKey = findLastKey;
-    lodash.floor = floor;
-    lodash.forEach = forEach;
-    lodash.forEachRight = forEachRight;
-    lodash.forIn = forIn;
-    lodash.forInRight = forInRight;
-    lodash.forOwn = forOwn;
-    lodash.forOwnRight = forOwnRight;
-    lodash.get = get;
-    lodash.gt = gt;
-    lodash.gte = gte;
-    lodash.has = has;
-    lodash.hasIn = hasIn;
-    lodash.head = head;
-    lodash.identity = identity;
-    lodash.includes = includes;
-    lodash.indexOf = indexOf;
-    lodash.inRange = inRange;
-    lodash.invoke = invoke;
-    lodash.isArguments = isArguments;
-    lodash.isArray = isArray;
-    lodash.isArrayBuffer = isArrayBuffer;
-    lodash.isArrayLike = isArrayLike;
-    lodash.isArrayLikeObject = isArrayLikeObject;
-    lodash.isBoolean = isBoolean;
-    lodash.isBuffer = isBuffer;
-    lodash.isDate = isDate;
-    lodash.isElement = isElement;
-    lodash.isEmpty = isEmpty;
-    lodash.isEqual = isEqual;
-    lodash.isEqualWith = isEqualWith;
-    lodash.isError = isError;
-    lodash.isFinite = isFinite;
-    lodash.isFunction = isFunction;
-    lodash.isInteger = isInteger;
-    lodash.isLength = isLength;
-    lodash.isMap = isMap;
-    lodash.isMatch = isMatch;
-    lodash.isMatchWith = isMatchWith;
-    lodash.isNaN = isNaN;
-    lodash.isNative = isNative;
-    lodash.isNil = isNil;
-    lodash.isNull = isNull;
-    lodash.isNumber = isNumber;
-    lodash.isObject = isObject;
-    lodash.isObjectLike = isObjectLike;
-    lodash.isPlainObject = isPlainObject;
-    lodash.isRegExp = isRegExp;
-    lodash.isSafeInteger = isSafeInteger;
-    lodash.isSet = isSet;
-    lodash.isString = isString;
-    lodash.isSymbol = isSymbol;
-    lodash.isTypedArray = isTypedArray;
-    lodash.isUndefined = isUndefined;
-    lodash.isWeakMap = isWeakMap;
-    lodash.isWeakSet = isWeakSet;
-    lodash.join = join;
-    lodash.kebabCase = kebabCase;
-    lodash.last = last;
-    lodash.lastIndexOf = lastIndexOf;
-    lodash.lowerCase = lowerCase;
-    lodash.lowerFirst = lowerFirst;
-    lodash.lt = lt;
-    lodash.lte = lte;
-    lodash.max = max;
-    lodash.maxBy = maxBy;
-    lodash.mean = mean;
-    lodash.meanBy = meanBy;
-    lodash.min = min;
-    lodash.minBy = minBy;
-    lodash.stubArray = stubArray;
-    lodash.stubFalse = stubFalse;
-    lodash.stubObject = stubObject;
-    lodash.stubString = stubString;
-    lodash.stubTrue = stubTrue;
-    lodash.multiply = multiply;
-    lodash.nth = nth;
-    lodash.noConflict = noConflict;
-    lodash.noop = noop;
-    lodash.now = now;
-    lodash.pad = pad;
-    lodash.padEnd = padEnd;
-    lodash.padStart = padStart;
-    lodash.parseInt = parseInt;
-    lodash.random = random;
-    lodash.reduce = reduce;
-    lodash.reduceRight = reduceRight;
-    lodash.repeat = repeat;
-    lodash.replace = replace;
-    lodash.result = result;
-    lodash.round = round;
-    lodash.runInContext = runInContext;
-    lodash.sample = sample;
-    lodash.size = size;
-    lodash.snakeCase = snakeCase;
-    lodash.some = some;
-    lodash.sortedIndex = sortedIndex;
-    lodash.sortedIndexBy = sortedIndexBy;
-    lodash.sortedIndexOf = sortedIndexOf;
-    lodash.sortedLastIndex = sortedLastIndex;
-    lodash.sortedLastIndexBy = sortedLastIndexBy;
-    lodash.sortedLastIndexOf = sortedLastIndexOf;
-    lodash.startCase = startCase;
-    lodash.startsWith = startsWith;
-    lodash.subtract = subtract;
-    lodash.sum = sum;
-    lodash.sumBy = sumBy;
-    lodash.template = template;
-    lodash.times = times;
-    lodash.toFinite = toFinite;
-    lodash.toInteger = toInteger;
-    lodash.toLength = toLength;
-    lodash.toLower = toLower;
-    lodash.toNumber = toNumber;
-    lodash.toSafeInteger = toSafeInteger;
-    lodash.toString = toString;
-    lodash.toUpper = toUpper;
-    lodash.trim = trim;
-    lodash.trimEnd = trimEnd;
-    lodash.trimStart = trimStart;
-    lodash.truncate = truncate;
-    lodash.unescape = unescape;
-    lodash.uniqueId = uniqueId;
-    lodash.upperCase = upperCase;
-    lodash.upperFirst = upperFirst;
+    lodash.add = add
+    lodash.attempt = attempt
+    lodash.camelCase = camelCase
+    lodash.capitalize = capitalize
+    lodash.ceil = ceil
+    lodash.clamp = clamp
+    lodash.clone = clone
+    lodash.cloneDeep = cloneDeep
+    lodash.cloneDeepWith = cloneDeepWith
+    lodash.cloneWith = cloneWith
+    lodash.conformsTo = conformsTo
+    lodash.deburr = deburr
+    lodash.defaultTo = defaultTo
+    lodash.divide = divide
+    lodash.endsWith = endsWith
+    lodash.eq = eq
+    lodash.escape = escape
+    lodash.escapeRegExp = escapeRegExp
+    lodash.every = every
+    lodash.find = find
+    lodash.findIndex = findIndex
+    lodash.findKey = findKey
+    lodash.findLast = findLast
+    lodash.findLastIndex = findLastIndex
+    lodash.findLastKey = findLastKey
+    lodash.floor = floor
+    lodash.forEach = forEach
+    lodash.forEachRight = forEachRight
+    lodash.forIn = forIn
+    lodash.forInRight = forInRight
+    lodash.forOwn = forOwn
+    lodash.forOwnRight = forOwnRight
+    lodash.get = get
+    lodash.gt = gt
+    lodash.gte = gte
+    lodash.has = has
+    lodash.hasIn = hasIn
+    lodash.head = head
+    lodash.identity = identity
+    lodash.includes = includes
+    lodash.indexOf = indexOf
+    lodash.inRange = inRange
+    lodash.invoke = invoke
+    lodash.isArguments = isArguments
+    lodash.isArray = isArray
+    lodash.isArrayBuffer = isArrayBuffer
+    lodash.isArrayLike = isArrayLike
+    lodash.isArrayLikeObject = isArrayLikeObject
+    lodash.isBoolean = isBoolean
+    lodash.isBuffer = isBuffer
+    lodash.isDate = isDate
+    lodash.isElement = isElement
+    lodash.isEmpty = isEmpty
+    lodash.isEqual = isEqual
+    lodash.isEqualWith = isEqualWith
+    lodash.isError = isError
+    lodash.isFinite = isFinite
+    lodash.isFunction = isFunction
+    lodash.isInteger = isInteger
+    lodash.isLength = isLength
+    lodash.isMap = isMap
+    lodash.isMatch = isMatch
+    lodash.isMatchWith = isMatchWith
+    lodash.isNaN = isNaN
+    lodash.isNative = isNative
+    lodash.isNil = isNil
+    lodash.isNull = isNull
+    lodash.isNumber = isNumber
+    lodash.isObject = isObject
+    lodash.isObjectLike = isObjectLike
+    lodash.isPlainObject = isPlainObject
+    lodash.isRegExp = isRegExp
+    lodash.isSafeInteger = isSafeInteger
+    lodash.isSet = isSet
+    lodash.isString = isString
+    lodash.isSymbol = isSymbol
+    lodash.isTypedArray = isTypedArray
+    lodash.isUndefined = isUndefined
+    lodash.isWeakMap = isWeakMap
+    lodash.isWeakSet = isWeakSet
+    lodash.join = join
+    lodash.kebabCase = kebabCase
+    lodash.last = last
+    lodash.lastIndexOf = lastIndexOf
+    lodash.lowerCase = lowerCase
+    lodash.lowerFirst = lowerFirst
+    lodash.lt = lt
+    lodash.lte = lte
+    lodash.max = max
+    lodash.maxBy = maxBy
+    lodash.mean = mean
+    lodash.meanBy = meanBy
+    lodash.min = min
+    lodash.minBy = minBy
+    lodash.stubArray = stubArray
+    lodash.stubFalse = stubFalse
+    lodash.stubObject = stubObject
+    lodash.stubString = stubString
+    lodash.stubTrue = stubTrue
+    lodash.multiply = multiply
+    lodash.nth = nth
+    lodash.noConflict = noConflict
+    lodash.noop = noop
+    lodash.now = now
+    lodash.pad = pad
+    lodash.padEnd = padEnd
+    lodash.padStart = padStart
+    lodash.parseInt = parseInt
+    lodash.random = random
+    lodash.reduce = reduce
+    lodash.reduceRight = reduceRight
+    lodash.repeat = repeat
+    lodash.replace = replace
+    lodash.result = result
+    lodash.round = round
+    lodash.runInContext = runInContext
+    lodash.sample = sample
+    lodash.size = size
+    lodash.snakeCase = snakeCase
+    lodash.some = some
+    lodash.sortedIndex = sortedIndex
+    lodash.sortedIndexBy = sortedIndexBy
+    lodash.sortedIndexOf = sortedIndexOf
+    lodash.sortedLastIndex = sortedLastIndex
+    lodash.sortedLastIndexBy = sortedLastIndexBy
+    lodash.sortedLastIndexOf = sortedLastIndexOf
+    lodash.startCase = startCase
+    lodash.startsWith = startsWith
+    lodash.subtract = subtract
+    lodash.sum = sum
+    lodash.sumBy = sumBy
+    lodash.template = template
+    lodash.times = times
+    lodash.toFinite = toFinite
+    lodash.toInteger = toInteger
+    lodash.toLength = toLength
+    lodash.toLower = toLower
+    lodash.toNumber = toNumber
+    lodash.toSafeInteger = toSafeInteger
+    lodash.toString = toString
+    lodash.toUpper = toUpper
+    lodash.trim = trim
+    lodash.trimEnd = trimEnd
+    lodash.trimStart = trimStart
+    lodash.truncate = truncate
+    lodash.unescape = unescape
+    lodash.uniqueId = uniqueId
+    lodash.upperCase = upperCase
+    lodash.upperFirst = upperFirst
 
     // Add aliases.
-    lodash.each = forEach;
-    lodash.eachRight = forEachRight;
-    lodash.first = head;
+    lodash.each = forEach
+    lodash.eachRight = forEachRight
+    lodash.first = head
 
-    mixin(lodash, (function() {
-      var source = {};
-      baseForOwn(lodash, function(func, methodName) {
-        if (!hasOwnProperty.call(lodash.prototype, methodName)) {
-          source[methodName] = func;
-        }
-      });
-      return source;
-    }()), { 'chain': false });
+    mixin(
+      lodash,
+      (function() {
+        var source = {}
+        baseForOwn(lodash, function(func, methodName) {
+          if (!hasOwnProperty.call(lodash.prototype, methodName)) {
+            source[methodName] = func
+          }
+        })
+        return source
+      })(),
+      {chain: false}
+    )
 
     /*------------------------------------------------------------------------*/
 
@@ -16831,230 +16992,238 @@
      * @memberOf _
      * @type {string}
      */
-    lodash.VERSION = VERSION;
+    lodash.VERSION = VERSION
 
     // Assign default placeholders.
     arrayEach(['bind', 'bindKey', 'curry', 'curryRight', 'partial', 'partialRight'], function(methodName) {
-      lodash[methodName].placeholder = lodash;
-    });
+      lodash[methodName].placeholder = lodash
+    })
 
     // Add `LazyWrapper` methods for `_.drop` and `_.take` variants.
     arrayEach(['drop', 'take'], function(methodName, index) {
       LazyWrapper.prototype[methodName] = function(n) {
-        n = n === undefined ? 1 : nativeMax(toInteger(n), 0);
+        n = n === undefined ? 1 : nativeMax(toInteger(n), 0)
 
-        var result = (this.__filtered__ && !index)
-          ? new LazyWrapper(this)
-          : this.clone();
+        var result = this.__filtered__ && !index ? new LazyWrapper(this) : this.clone()
 
         if (result.__filtered__) {
-          result.__takeCount__ = nativeMin(n, result.__takeCount__);
+          result.__takeCount__ = nativeMin(n, result.__takeCount__)
         } else {
           result.__views__.push({
-            'size': nativeMin(n, MAX_ARRAY_LENGTH),
-            'type': methodName + (result.__dir__ < 0 ? 'Right' : '')
-          });
+            size: nativeMin(n, MAX_ARRAY_LENGTH),
+            type: methodName + (result.__dir__ < 0 ? 'Right' : '')
+          })
         }
-        return result;
-      };
+        return result
+      }
 
       LazyWrapper.prototype[methodName + 'Right'] = function(n) {
-        return this.reverse()[methodName](n).reverse();
-      };
-    });
+        return this.reverse()
+          [methodName](n)
+          .reverse()
+      }
+    })
 
     // Add `LazyWrapper` methods that accept an `iteratee` value.
     arrayEach(['filter', 'map', 'takeWhile'], function(methodName, index) {
       var type = index + 1,
-          isFilter = type == LAZY_FILTER_FLAG || type == LAZY_WHILE_FLAG;
+        isFilter = type == LAZY_FILTER_FLAG || type == LAZY_WHILE_FLAG
 
       LazyWrapper.prototype[methodName] = function(iteratee) {
-        var result = this.clone();
+        var result = this.clone()
         result.__iteratees__.push({
-          'iteratee': getIteratee(iteratee, 3),
-          'type': type
-        });
-        result.__filtered__ = result.__filtered__ || isFilter;
-        return result;
-      };
-    });
+          iteratee: getIteratee(iteratee, 3),
+          type: type
+        })
+        result.__filtered__ = result.__filtered__ || isFilter
+        return result
+      }
+    })
 
     // Add `LazyWrapper` methods for `_.head` and `_.last`.
     arrayEach(['head', 'last'], function(methodName, index) {
-      var takeName = 'take' + (index ? 'Right' : '');
+      var takeName = 'take' + (index ? 'Right' : '')
 
       LazyWrapper.prototype[methodName] = function() {
-        return this[takeName](1).value()[0];
-      };
-    });
+        return this[takeName](1).value()[0]
+      }
+    })
 
     // Add `LazyWrapper` methods for `_.initial` and `_.tail`.
     arrayEach(['initial', 'tail'], function(methodName, index) {
-      var dropName = 'drop' + (index ? '' : 'Right');
+      var dropName = 'drop' + (index ? '' : 'Right')
 
       LazyWrapper.prototype[methodName] = function() {
-        return this.__filtered__ ? new LazyWrapper(this) : this[dropName](1);
-      };
-    });
+        return this.__filtered__ ? new LazyWrapper(this) : this[dropName](1)
+      }
+    })
 
     LazyWrapper.prototype.compact = function() {
-      return this.filter(identity);
-    };
+      return this.filter(identity)
+    }
 
     LazyWrapper.prototype.find = function(predicate) {
-      return this.filter(predicate).head();
-    };
+      return this.filter(predicate).head()
+    }
 
     LazyWrapper.prototype.findLast = function(predicate) {
-      return this.reverse().find(predicate);
-    };
+      return this.reverse().find(predicate)
+    }
 
     LazyWrapper.prototype.invokeMap = baseRest(function(path, args) {
       if (typeof path == 'function') {
-        return new LazyWrapper(this);
+        return new LazyWrapper(this)
       }
       return this.map(function(value) {
-        return baseInvoke(value, path, args);
-      });
-    });
+        return baseInvoke(value, path, args)
+      })
+    })
 
     LazyWrapper.prototype.reject = function(predicate) {
-      return this.filter(negate(getIteratee(predicate)));
-    };
+      return this.filter(negate(getIteratee(predicate)))
+    }
 
     LazyWrapper.prototype.slice = function(start, end) {
-      start = toInteger(start);
+      start = toInteger(start)
 
-      var result = this;
+      var result = this
       if (result.__filtered__ && (start > 0 || end < 0)) {
-        return new LazyWrapper(result);
+        return new LazyWrapper(result)
       }
       if (start < 0) {
-        result = result.takeRight(-start);
+        result = result.takeRight(-start)
       } else if (start) {
-        result = result.drop(start);
+        result = result.drop(start)
       }
       if (end !== undefined) {
-        end = toInteger(end);
-        result = end < 0 ? result.dropRight(-end) : result.take(end - start);
+        end = toInteger(end)
+        result = end < 0 ? result.dropRight(-end) : result.take(end - start)
       }
-      return result;
-    };
+      return result
+    }
 
     LazyWrapper.prototype.takeRightWhile = function(predicate) {
-      return this.reverse().takeWhile(predicate).reverse();
-    };
+      return this.reverse()
+        .takeWhile(predicate)
+        .reverse()
+    }
 
     LazyWrapper.prototype.toArray = function() {
-      return this.take(MAX_ARRAY_LENGTH);
-    };
+      return this.take(MAX_ARRAY_LENGTH)
+    }
 
     // Add `LazyWrapper` methods to `lodash.prototype`.
     baseForOwn(LazyWrapper.prototype, function(func, methodName) {
       var checkIteratee = /^(?:filter|find|map|reject)|While$/.test(methodName),
-          isTaker = /^(?:head|last)$/.test(methodName),
-          lodashFunc = lodash[isTaker ? ('take' + (methodName == 'last' ? 'Right' : '')) : methodName],
-          retUnwrapped = isTaker || /^find/.test(methodName);
+        isTaker = /^(?:head|last)$/.test(methodName),
+        lodashFunc = lodash[isTaker ? 'take' + (methodName == 'last' ? 'Right' : '') : methodName],
+        retUnwrapped = isTaker || /^find/.test(methodName)
 
       if (!lodashFunc) {
-        return;
+        return
       }
       lodash.prototype[methodName] = function() {
         var value = this.__wrapped__,
-            args = isTaker ? [1] : arguments,
-            isLazy = value instanceof LazyWrapper,
-            iteratee = args[0],
-            useLazy = isLazy || isArray(value);
+          args = isTaker ? [1] : arguments,
+          isLazy = value instanceof LazyWrapper,
+          iteratee = args[0],
+          useLazy = isLazy || isArray(value)
 
         var interceptor = function(value) {
-          var result = lodashFunc.apply(lodash, arrayPush([value], args));
-          return (isTaker && chainAll) ? result[0] : result;
-        };
+          var result = lodashFunc.apply(lodash, arrayPush([value], args))
+          return isTaker && chainAll ? result[0] : result
+        }
 
         if (useLazy && checkIteratee && typeof iteratee == 'function' && iteratee.length != 1) {
           // Avoid lazy use if the iteratee has a "length" value other than `1`.
-          isLazy = useLazy = false;
+          isLazy = useLazy = false
         }
         var chainAll = this.__chain__,
-            isHybrid = !!this.__actions__.length,
-            isUnwrapped = retUnwrapped && !chainAll,
-            onlyLazy = isLazy && !isHybrid;
+          isHybrid = !!this.__actions__.length,
+          isUnwrapped = retUnwrapped && !chainAll,
+          onlyLazy = isLazy && !isHybrid
 
         if (!retUnwrapped && useLazy) {
-          value = onlyLazy ? value : new LazyWrapper(this);
-          var result = func.apply(value, args);
-          result.__actions__.push({ 'func': thru, 'args': [interceptor], 'thisArg': undefined });
-          return new LodashWrapper(result, chainAll);
+          value = onlyLazy ? value : new LazyWrapper(this)
+          var result = func.apply(value, args)
+          result.__actions__.push({
+            func: thru,
+            args: [interceptor],
+            thisArg: undefined
+          })
+          return new LodashWrapper(result, chainAll)
         }
         if (isUnwrapped && onlyLazy) {
-          return func.apply(this, args);
+          return func.apply(this, args)
         }
-        result = this.thru(interceptor);
-        return isUnwrapped ? (isTaker ? result.value()[0] : result.value()) : result;
-      };
-    });
+        result = this.thru(interceptor)
+        return isUnwrapped ? (isTaker ? result.value()[0] : result.value()) : result
+      }
+    })
 
     // Add `Array` methods to `lodash.prototype`.
     arrayEach(['pop', 'push', 'shift', 'sort', 'splice', 'unshift'], function(methodName) {
       var func = arrayProto[methodName],
-          chainName = /^(?:push|sort|unshift)$/.test(methodName) ? 'tap' : 'thru',
-          retUnwrapped = /^(?:pop|shift)$/.test(methodName);
+        chainName = /^(?:push|sort|unshift)$/.test(methodName) ? 'tap' : 'thru',
+        retUnwrapped = /^(?:pop|shift)$/.test(methodName)
 
       lodash.prototype[methodName] = function() {
-        var args = arguments;
+        var args = arguments
         if (retUnwrapped && !this.__chain__) {
-          var value = this.value();
-          return func.apply(isArray(value) ? value : [], args);
+          var value = this.value()
+          return func.apply(isArray(value) ? value : [], args)
         }
         return this[chainName](function(value) {
-          return func.apply(isArray(value) ? value : [], args);
-        });
-      };
-    });
+          return func.apply(isArray(value) ? value : [], args)
+        })
+      }
+    })
 
     // Map minified method names to their real names.
     baseForOwn(LazyWrapper.prototype, function(func, methodName) {
-      var lodashFunc = lodash[methodName];
+      var lodashFunc = lodash[methodName]
       if (lodashFunc) {
-        var key = (lodashFunc.name + ''),
-            names = realNames[key] || (realNames[key] = []);
+        var key = lodashFunc.name + '',
+          names = realNames[key] || (realNames[key] = [])
 
-        names.push({ 'name': methodName, 'func': lodashFunc });
+        names.push({name: methodName, func: lodashFunc})
       }
-    });
+    })
 
-    realNames[createHybrid(undefined, WRAP_BIND_KEY_FLAG).name] = [{
-      'name': 'wrapper',
-      'func': undefined
-    }];
+    realNames[createHybrid(undefined, WRAP_BIND_KEY_FLAG).name] = [
+      {
+        name: 'wrapper',
+        func: undefined
+      }
+    ]
 
     // Add methods to `LazyWrapper`.
-    LazyWrapper.prototype.clone = lazyClone;
-    LazyWrapper.prototype.reverse = lazyReverse;
-    LazyWrapper.prototype.value = lazyValue;
+    LazyWrapper.prototype.clone = lazyClone
+    LazyWrapper.prototype.reverse = lazyReverse
+    LazyWrapper.prototype.value = lazyValue
 
     // Add chain sequence methods to the `lodash` wrapper.
-    lodash.prototype.at = wrapperAt;
-    lodash.prototype.chain = wrapperChain;
-    lodash.prototype.commit = wrapperCommit;
-    lodash.prototype.next = wrapperNext;
-    lodash.prototype.plant = wrapperPlant;
-    lodash.prototype.reverse = wrapperReverse;
-    lodash.prototype.toJSON = lodash.prototype.valueOf = lodash.prototype.value = wrapperValue;
+    lodash.prototype.at = wrapperAt
+    lodash.prototype.chain = wrapperChain
+    lodash.prototype.commit = wrapperCommit
+    lodash.prototype.next = wrapperNext
+    lodash.prototype.plant = wrapperPlant
+    lodash.prototype.reverse = wrapperReverse
+    lodash.prototype.toJSON = lodash.prototype.valueOf = lodash.prototype.value = wrapperValue
 
     // Add lazy aliases.
-    lodash.prototype.first = lodash.prototype.head;
+    lodash.prototype.first = lodash.prototype.head
 
     if (symIterator) {
-      lodash.prototype[symIterator] = wrapperToIterator;
+      lodash.prototype[symIterator] = wrapperToIterator
     }
-    return lodash;
-  });
+    return lodash
+  }
 
   /*--------------------------------------------------------------------------*/
 
   // Export lodash.
-  var _ = runInContext();
+  var _ = runInContext()
 
   // Some AMD build optimizers, like r.js, check for condition patterns like:
   if (typeof define == 'function' && typeof define.amd == 'object' && define.amd) {
@@ -17062,23 +17231,22 @@
     // loaded by a script tag in the presence of an AMD loader.
     // See http://requirejs.org/docs/errors.html#mismatch for more details.
     // Use `_.noConflict` to remove Lodash from the global object.
-    root._ = _;
+    root._ = _
 
     // Define as an anonymous module so, through path mapping, it can be
     // referenced as the "underscore" module.
     define(function() {
-      return _;
-    });
+      return _
+    })
   }
   // Check for `exports` after `define` in case a build optimizer adds it.
   else if (freeModule) {
     // Export for Node.js.
-    (freeModule.exports = _)._ = _;
+    ;(freeModule.exports = _)._ = _
     // Export for CommonJS support.
-    freeExports._ = _;
-  }
-  else {
+    freeExports._ = _
+  } else {
     // Export to the global object.
-    root._ = _;
+    root._ = _
   }
-}.call(this));
+}.call(this))

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,6 +39,12 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
+
 argparse@^1.0.7:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
@@ -78,6 +84,10 @@ balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
 brace-expansion@^1.0.0:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
@@ -85,11 +95,18 @@ brace-expansion@^1.0.0:
     balanced-match "^0.4.1"
     concat-map "0.0.1"
 
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
 buffer-shims@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
 
-builtin-modules@^1.1.1:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -113,6 +130,18 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.1, chalk@^2.1.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+ci-info@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.3.1.tgz#da21bc65a5f0d0d250c19a169065532b42fa048c"
+
 circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
@@ -122,6 +151,16 @@ cli-cursor@^1.0.1:
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
   dependencies:
     restore-cursor "^1.0.1"
+
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  dependencies:
+    restore-cursor "^2.0.0"
+
+cli-spinners@^1.0.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.3.1.tgz#002c1990912d0d59580c93bd36c056de99e4259a"
 
 cli-width@^2.0.0:
   version "2.1.0"
@@ -134,6 +173,16 @@ co@^4.6.0:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+color-convert@^1.9.0:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.2.tgz#49881b8fba67df12a96bdf3f56c0aab9e7913147"
+  dependencies:
+    color-name "1.1.1"
+
+color-name@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -154,6 +203,22 @@ contains-path@^0.1.0:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cosmiconfig@^5.0.2:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.6.tgz#dca6cf680a0bd03589aff684700858c81abeeb39"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 d@1:
   version "1.0.0"
@@ -211,6 +276,10 @@ del@^2.0.2:
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
 
+diff-match-patch@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.1.tgz#d5f880213d82fbc124d2b95111fb3c033dbad7fa"
+
 doctrine@1.5.0, doctrine@^1.2.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -228,6 +297,12 @@ doctrine@^2.0.0:
 error-ex@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+  dependencies:
+    is-arrayish "^0.2.1"
+
+error-ex@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   dependencies:
     is-arrayish "^0.2.1"
 
@@ -430,6 +505,10 @@ esprima@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
+esprima@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+
 esquery@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
@@ -461,6 +540,18 @@ event-emitter@~0.3.5:
   dependencies:
     d "1"
     es5-ext "~0.10.14"
+
+execa@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.9.0.tgz#adb7ce62cf985071f60580deb4a88b9e34712d01"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -495,11 +586,17 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
-find-up@^2.0.0:
+find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  dependencies:
+    locate-path "^3.0.0"
 
 flat-cache@^1.2.1:
   version "1.2.2"
@@ -536,6 +633,14 @@ get-stdin@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
@@ -544,6 +649,17 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -572,15 +688,42 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 has@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
   dependencies:
     function-bind "^1.0.2"
 
+hosted-git-info@^2.1.4:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
+
+husky@^1.0.0-rc.13:
+  version "1.0.0-rc.13"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-1.0.0-rc.13.tgz#49c3cc210bfeac24d4ad272f770b7505c9091828"
+  dependencies:
+    cosmiconfig "^5.0.2"
+    execa "^0.9.0"
+    find-up "^3.0.0"
+    get-stdin "^6.0.0"
+    is-ci "^1.1.0"
+    pkg-dir "^3.0.0"
+    please-upgrade-node "^3.1.1"
+    read-pkg "^4.0.1"
+    run-node "^1.0.0"
+    slash "^2.0.0"
+
 ignore@^3.0.11, ignore@^3.0.9, ignore@^3.2.0:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.7.tgz#4810ca5f1d8eca5595213a34b94f2eb4ed926bbd"
+
+ignore@^3.3.7:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -623,13 +766,29 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
 
+is-builtin-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
+  dependencies:
+    builtin-modules "^1.0.0"
+
 is-callable@^1.1.1, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
 
+is-ci@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.0.tgz#3f4a08d6303a09882cef3f0fb97439c5f5ce2d53"
+  dependencies:
+    ci-info "^1.3.0"
+
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -682,6 +841,10 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
 is-symbol@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
@@ -689,6 +852,10 @@ is-symbol@^1.0.1:
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
 js-tokens@^3.0.0:
   version "3.0.1"
@@ -700,6 +867,17 @@ js-yaml@^3.5.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^3.1.1"
+
+js-yaml@^3.9.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
 
 json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   version "1.0.1"
@@ -742,6 +920,13 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
@@ -750,11 +935,34 @@ lodash@^4.0.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+log-symbols@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  dependencies:
+    chalk "^2.0.1"
+
+lru-cache@^4.0.1:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
+mimic-fn@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+
 minimatch@^3.0.2, minimatch@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
     brace-expansion "^1.0.0"
+
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
 
 minimist@0.0.8:
   version "0.0.8"
@@ -769,6 +977,10 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+mri@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.1.tgz#85aa26d3daeeeedf80dc5984af95cc5ca5cad9f1"
 
 ms@0.7.1:
   version "0.7.1"
@@ -785,6 +997,21 @@ mute-stream@0.0.5:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+normalize-package-data@^2.3.2:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
+  dependencies:
+    hosted-git-info "^2.1.4"
+    is-builtin-module "^1.0.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -816,6 +1043,12 @@ onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
 
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  dependencies:
+    mimic-fn "^1.0.0"
+
 optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
@@ -827,13 +1060,32 @@ optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
+ora@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-1.4.0.tgz#884458215b3a5d4097592285f93321bb7a79e2e5"
+  dependencies:
+    chalk "^2.1.0"
+    cli-cursor "^2.1.0"
+    cli-spinners "^1.0.1"
+    log-symbols "^2.1.0"
+
 os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+
 p-limit@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
+
+p-limit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec"
+  dependencies:
+    p-try "^2.0.0"
 
 p-locate@^2.0.0:
   version "2.0.0"
@@ -841,11 +1093,28 @@ p-locate@^2.0.0:
   dependencies:
     p-limit "^1.1.0"
 
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  dependencies:
+    p-limit "^2.0.0"
+
+p-try@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
+
 parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
   dependencies:
     error-ex "^1.2.0"
+
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
 
 path-exists@^2.0.0:
   version "2.1.0"
@@ -865,6 +1134,10 @@ path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
@@ -872,6 +1145,10 @@ path-parse@^1.0.5:
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -904,19 +1181,47 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  dependencies:
+    find-up "^3.0.0"
+
 pkg-up@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-1.0.0.tgz#3e08fb461525c4421624a33b9f7e6d0af5b05a26"
   dependencies:
     find-up "^1.0.0"
 
+please-upgrade-node@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
+  dependencies:
+    semver-compare "^1.0.0"
+
 pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
 
+precise-commits@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/precise-commits/-/precise-commits-1.0.2.tgz#4659be01a9c3310f50ce51ddf913fead1d7cc940"
+  dependencies:
+    diff-match-patch "^1.0.0"
+    execa "^0.9.0"
+    find-up "^2.1.0"
+    glob "^7.1.2"
+    ignore "^3.3.7"
+    mri "^1.1.0"
+    ora "^1.3.0"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+
+prettier@^1.14.2:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -925,6 +1230,18 @@ process-nextick-args@~1.0.6:
 progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
+read-pkg@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
+  dependencies:
+    normalize-package-data "^2.3.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
 
 readable-stream@^2.2.2:
   version "2.2.9"
@@ -976,6 +1293,13 @@ restore-cursor@^1.0.1:
     exit-hook "^1.0.0"
     onetime "^1.0.0"
 
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
 rimraf@^2.2.8:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
@@ -988,6 +1312,10 @@ run-async@^0.1.0:
   dependencies:
     once "^1.3.0"
 
+run-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
+
 run-parallel@^1.1.2:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.6.tgz#29003c9a2163e01e2d2dfc90575f2c6c1d61a039"
@@ -996,9 +1324,27 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+
+"semver@2 || 3 || 4 || 5":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
+
 semver@5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
 shelljs@^0.7.5:
   version "0.7.7"
@@ -1008,9 +1354,39 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
+signal-exit@^3.0.0, signal-exit@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+
+spdx-correct@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
+  dependencies:
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-exceptions@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
+
+spdx-expression-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -1070,6 +1446,10 @@ strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -1077,6 +1457,12 @@ strip-json-comments@~2.0.1:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+
+supports-color@^5.3.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
 
 table@^3.7.8:
   version "3.8.3"
@@ -1125,6 +1511,19 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
+validate-npm-package-license@^3.0.1:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
+  dependencies:
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
+
+which@^1.2.9:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  dependencies:
+    isexe "^2.0.0"
+
 wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
@@ -1142,3 +1541,7 @@ write@^0.2.1:
 xtend@^4.0.0, xtend@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"


### PR DESCRIPTION
in the interest of respecting the existing style guide and reduced diff count, prettier was configured to adhere to existing conventions.

steps taken:

* yarn added deps for automated formatting (on precommit)

* `prettier --print-width 120 --bracket-spacing false --single-quote --no-semi --write "**/*.js"`

* tailored config to align with project standards

gotcha: might be wise to revert changes in `vendor/lodash.js` /shrug

really cool project, will be attempting support for providers / additional features in future prs!